### PR TITLE
Add -o --output-dir option

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,6 +48,9 @@ func init() {
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cpma.yaml)")
+
+	rootCmd.Flags().StringP("output-dir", "o", "", "set the directory to store extracted configuration.")
+	viper.BindPFlag("outputPath", rootCmd.Flags().Lookup("output-dir"))
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cpma.go
+++ b/cpma.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"path/filepath"
+
 	"github.com/fusor/cpma/cmd"
 	"github.com/fusor/cpma/env"
 )
@@ -14,10 +16,10 @@ func main() {
 
 	srcFilePath := "/etc/origin/master/master-config.yaml"
 	dstFilePath := "./master-config.yaml"
-	sftpclient.GetFile(srcFilePath, dstFilePath)
+	sftpclient.GetFile(srcFilePath, filepath.Join(config.OutputPath, dstFilePath))
 
 	srcFilePath = "/etc/origin/node/node-config.yaml"
 	dstFilePath = "./node-config.yaml"
-	sftpclient.GetFile(srcFilePath, dstFilePath)
+	sftpclient.GetFile(srcFilePath, filepath.Join(config.OutputPath, dstFilePath))
 
 }

--- a/env/env.go
+++ b/env/env.go
@@ -9,7 +9,8 @@ import (
 
 // Info structures the application settings.
 type Info struct {
-	SFTP sftpclient.Info `mapstructure:"Source"`
+	SFTP       sftpclient.Info `mapstructure:"Source"`
+	OutputPath string          `mapstructure:"outputPath"`
 }
 
 // New returns a instance of the application settings.

--- a/internal/sftpclient/sftpclient.go
+++ b/internal/sftpclient/sftpclient.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
 	"time"
 
@@ -76,6 +77,7 @@ func (c *Client) GetFile(srcFilePath string, dstFilePath string) {
 	}
 	defer srcFile.Close()
 
+	os.MkdirAll(path.Dir(dstFilePath), 0755)
 	dstFile, err := os.Create(dstFilePath)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
this is helpful for
- defining the output directory for extracted control plane
  configuration in general
- as well as to run the tool in the loop against various target
  control planes and save the output in a respective directories

Signed-off-by: Anton Arapov <arapov@gmail.com>