### PR TITLE
set the default outputDir and make it OS agnostic

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"path"
 
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
@@ -51,6 +52,7 @@ func init() {
 
 	rootCmd.Flags().StringP("output-dir", "o", "", "set the directory to store extracted configuration.")
 	viper.BindPFlag("outputPath", rootCmd.Flags().Lookup("output-dir"))
+	viper.SetDefault("outputPath", path.Dir(""))
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/env/env.go
+++ b/env/env.go
@@ -41,7 +41,7 @@ func (config *Info) FetchSrc() int {
 	defer sftpclient.Close()
 
 	for key, nodeconfig := range config.SrCluster {
-		srcFilePath := nodeconfig.Path + "/" + nodeconfig.FileName
+		srcFilePath := filepath.Join(nodeconfig.Path, nodeconfig.FileName)
 		dstFilePath := filepath.Join(config.OutputPath, srcFilePath)
 		sftpclient.GetFile(srcFilePath, dstFilePath)
 


### PR DESCRIPTION
Current dir is the default for the output.

Signed-off-by: Anton Arapov <arapov@gmail.com>