### PR TITLE
Fix error on --help command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"path"
 
+	"github.com/fusor/cpma/env"
 	"github.com/fusor/cpma/internal/config"
 	log "github.com/sirupsen/logrus"
 
@@ -31,9 +32,27 @@ var rootCmd = &cobra.Command{
 	Short: "Helps migration cluster configuration of a OCP 3.x cluster to OCP 4.x",
 	Long:  `Helps migration cluster configuration of a OCP 3.x cluster to OCP 4.x`,
 	Run: func(cmd *cobra.Command, args []string) {
+		// Set loglevel to debug
 		if debugLogLevel {
 			log.SetLevel(log.DebugLevel)
 		}
+
+		err := config.InitConfig()
+		if err != nil {
+			log.Fatal(err, "\n")
+		}
+
+		envConfig := env.New()
+
+		if envConfig.LocalOnly {
+			envConfig.LoadSrc()
+		} else {
+			envConfig.FetchSrc()
+		}
+
+		envConfig.Parse()
+
+		log.Print(envConfig.Show())
 	},
 }
 
@@ -46,7 +65,7 @@ func Execute() {
 }
 
 func init() {
-	cobra.OnInitialize(config.InitConfig)
+	cobra.OnInitialize()
 	rootCmd.PersistentFlags().StringVar(&config.ConfigFile, "config", "", "config file (default is $HOME/.cpma.yaml)")
 	rootCmd.PersistentFlags().BoolVar(&debugLogLevel, "debug", false, "set log level to debug")
 

--- a/cpma.go
+++ b/cpma.go
@@ -2,23 +2,9 @@ package main
 
 import (
 	"github.com/fusor/cpma/cmd"
-	"github.com/fusor/cpma/env"
 	_ "github.com/fusor/cpma/internal/log"
-	log "github.com/sirupsen/logrus"
 )
 
 func main() {
 	cmd.Execute()
-
-	config := env.New()
-
-	if config.LocalOnly {
-		config.LoadSrc()
-	} else {
-		config.FetchSrc()
-	}
-
-	config.Parse()
-
-	log.Print(config.Show())
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,9 +1,6 @@
 package config
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
 )
@@ -19,12 +16,11 @@ func Config() *viper.Viper {
 }
 
 // InitConfig initialize config
-func InitConfig() {
+func InitConfig() error {
 	// Find home directory.
 	home, err := homedir.Dir()
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return err
 	}
 	defaultConfig.Set("home", home)
 
@@ -41,9 +37,10 @@ func InitConfig() {
 
 	// If a config file is found, read it in.
 	if err := defaultConfig.ReadInConfig(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return err
 	}
+
+	return nil
 }
 
 func init() {


### PR DESCRIPTION
Moving logic away from main() should fix error we see when using `--help`. In future I would prefer to remove code from  `rootCmd.Run`