### PR TITLE
Add keystone oauth, secrets refactor and tests

### DIFF
--- a/ocp4/oauth/htpasswd.go
+++ b/ocp4/oauth/htpasswd.go
@@ -39,7 +39,7 @@ func buildHTPasswdIP(serializer *json.Serializer, p configv1.IdentityProvider) (
 	//htpasswdFile := Fetch_File(htpasswd.File)
 	htpasswdFile := "This is pretend content"
 	encoded := base64.StdEncoding.EncodeToString([]byte(htpasswdFile))
-	secret := secrets.GenSecretFile(secretName, encoded, "openshift-config")
+	secret := secrets.GenSecretFile(secretName, encoded, "openshift-config", "htpasswd")
 
 	return idP, *secret
 }

--- a/ocp4/oauth/keystone.go
+++ b/ocp4/oauth/keystone.go
@@ -1,0 +1,63 @@
+package oauth
+
+import (
+	"encoding/base64"
+
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+
+	"github.com/fusor/cpma/ocp4/secrets"
+	configv1 "github.com/openshift/api/legacyconfig/v1"
+)
+
+type identityProviderKeystone struct {
+	Name          string `yaml:"name"`
+	Challenge     bool   `yaml:"challenge"`
+	Login         bool   `yaml:"login"`
+	MappingMethod string `yaml:"mappingMethod"`
+	Type          string `yaml:"type"`
+	Keystone      struct {
+		DomainName string `yaml:"domainName"`
+		URL        string `yaml:"url"`
+		CA         struct {
+			Name string `yaml:"name"`
+		} `yaml:"ca"`
+		TLSClientCert struct {
+			Name string `yaml:"name"`
+		} `yaml:"tlsClientCert"`
+		TLSClientKey struct {
+			Name string `yaml:"name"`
+		} `yaml:"tlsClientKey"`
+	} `yaml:"keystone"`
+}
+
+func buildKeystoneIP(serializer *json.Serializer, p configv1.IdentityProvider) (identityProviderKeystone, secrets.Secret, secrets.Secret) {
+	var idP identityProviderKeystone
+	var keystone configv1.KeystonePasswordIdentityProvider
+	_, _, _ = serializer.Decode(p.Provider.Raw, nil, &keystone)
+
+	idP.Type = "Keystone"
+	idP.Name = p.Name
+	idP.Challenge = p.UseAsChallenger
+	idP.Login = p.UseAsLogin
+	idP.MappingMethod = p.MappingMethod
+	idP.Keystone.DomainName = keystone.DomainName
+	idP.Keystone.URL = keystone.URL
+	idP.Keystone.CA.Name = keystone.CA
+
+	certSecretName := p.Name + "-client-cert-secret"
+	idP.Keystone.TLSClientCert.Name = certSecretName
+
+	// TODO: Fetch cert and key
+	certFile := "456This is pretend content"
+	encoded := base64.StdEncoding.EncodeToString([]byte(certFile))
+	certSecret := secrets.GenSecretFile(certSecretName, encoded, "openshift-config", "keystone")
+
+	keySecretName := p.Name + "-client-key-secret"
+	idP.Keystone.TLSClientKey.Name = keySecretName
+
+	keyFile := "123This is pretend content"
+	encoded = base64.StdEncoding.EncodeToString([]byte(keyFile))
+	keySecret := secrets.GenSecretFile(keySecretName, encoded, "openshift-config", "keystone")
+
+	return idP, *certSecret, *keySecret
+}

--- a/ocp4/oauth/keystone_test.go
+++ b/ocp4/oauth/keystone_test.go
@@ -1,0 +1,41 @@
+package oauth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fusor/cpma/ocp3"
+)
+
+func TestTranslateMasterConfigKeystone(t *testing.T) {
+	testConfig := ocp3.Config{
+		Masterf: "../../test/oauth/keystone-test-master-config.yaml",
+	}
+	masterConfig := testConfig.ParseMaster()
+
+	var expectedCrd OAuthCRD
+	expectedCrd.APIVersion = "config.openshift.io/v1"
+	expectedCrd.Kind = "OAuth"
+	expectedCrd.MetaData.Name = "cluster"
+	expectedCrd.MetaData.NameSpace = "openshift-config"
+
+	var keystoneIDP identityProviderKeystone
+	keystoneIDP.Type = "Keystone"
+	keystoneIDP.Challenge = true
+	keystoneIDP.Login = true
+	keystoneIDP.Name = "my_keystone_provider"
+	keystoneIDP.MappingMethod = "claim"
+	keystoneIDP.Keystone.DomainName = "default"
+	keystoneIDP.Keystone.URL = "http://fake.url:5000"
+	keystoneIDP.Keystone.CA.Name = "keystone.pem"
+	keystoneIDP.Keystone.TLSClientCert.Name = "my_keystone_provider-client-cert-secret"
+	keystoneIDP.Keystone.TLSClientKey.Name = "my_keystone_provider-client-key-secret"
+
+	expectedCrd.Spec.IdentityProviders = append(expectedCrd.Spec.IdentityProviders, keystoneIDP)
+
+	resCrd, _, err := Translate(masterConfig.OAuthConfig)
+	require.NoError(t, err)
+	assert.Equal(t, &expectedCrd, resCrd)
+}

--- a/ocp4/oauth/oauth.go
+++ b/ocp4/oauth/oauth.go
@@ -79,6 +79,11 @@ func Translate(oauthconfig *configv1.OAuthConfig) (*OAuthCRD, []secrets.Secret, 
 		case "RequestHeaderIdentityProvider":
 			idP := buildRequestHeaderIP(serializer, p)
 			oauthCrd.Spec.IdentityProviders = append(oauthCrd.Spec.IdentityProviders, idP)
+		case "KeystonePasswordIdentityProvider":
+			idP, certSecret, keySercret := buildKeystoneIP(serializer, p)
+			oauthCrd.Spec.IdentityProviders = append(oauthCrd.Spec.IdentityProviders, idP)
+			secrets = append(secrets, certSecret)
+			secrets = append(secrets, keySercret)
 		default:
 			logrus.Infof("Can't handle %s OAuth kind", kind)
 		}

--- a/ocp4/oauth/oauth_test.go
+++ b/ocp4/oauth/oauth_test.go
@@ -21,5 +21,6 @@ func TestTranslateMasterConfig(t *testing.T) {
 	assert.Equal(t, resCrd.Spec.IdentityProviders[1].(identityProviderGitLab).Type, "GitLab")
 	assert.Equal(t, resCrd.Spec.IdentityProviders[2].(identityProviderGoogle).Type, "Google")
 	assert.Equal(t, resCrd.Spec.IdentityProviders[3].(identityProviderHTPasswd).Type, "HTPasswd")
-	assert.Equal(t, resCrd.Spec.IdentityProviders[4].(identityProviderRequestHeader).Type, "RequestHeader")
+	assert.Equal(t, resCrd.Spec.IdentityProviders[4].(identityProviderKeystone).Type, "Keystone")
+	assert.Equal(t, resCrd.Spec.IdentityProviders[5].(identityProviderRequestHeader).Type, "RequestHeader")
 }

--- a/ocp4/secrets/secrets.go
+++ b/ocp4/secrets/secrets.go
@@ -60,7 +60,7 @@ func buildData(idenityProviderType, encodedSecret string) interface{} {
 	case "htpasswd":
 		data = HTPasswdFileSecret{HTPasswd: encodedSecret}
 	default:
-		logrus.Fatal("Not valid idenity provider type", idenityProviderType)
+		logrus.Fatal("Not valid idenity provider type ", idenityProviderType)
 	}
 
 	return data

--- a/ocp4/secrets/secrets.go
+++ b/ocp4/secrets/secrets.go
@@ -8,8 +8,12 @@ import (
 // TODO: Comment exported functions and structures.
 // We may want to unexport some...
 
-type FileSecret struct {
+type HTPasswdFileSecret struct {
 	HTPasswd string `yaml:"htpasswd"`
+}
+
+type KeystoneFileSecret struct {
+	Keystone string `yaml:"keystone"`
 }
 
 type LiteralSecret struct {
@@ -31,10 +35,12 @@ type MetaData struct {
 
 var APIVersion = "v1"
 
-func GenSecretFile(name string, encodedSecret string, namespace string) *Secret {
+func GenSecretFile(name string, encodedSecret string, namespace string, idenityProviderType string) *Secret {
+	data := buildData(idenityProviderType, encodedSecret)
+
 	var secret = Secret{
 		APIVersion: APIVersion,
-		Data:       FileSecret{HTPasswd: encodedSecret},
+		Data:       data,
 		Kind:       "Secret",
 		Type:       "Opaque",
 		MetaData: MetaData{
@@ -43,6 +49,21 @@ func GenSecretFile(name string, encodedSecret string, namespace string) *Secret 
 		},
 	}
 	return &secret
+}
+
+func buildData(idenityProviderType, encodedSecret string) interface{} {
+	var data interface{}
+
+	switch idenityProviderType {
+	case "keystone":
+		data = KeystoneFileSecret{Keystone: encodedSecret}
+	case "htpasswd":
+		data = HTPasswdFileSecret{HTPasswd: encodedSecret}
+	default:
+		logrus.Fatal("Not valid idenity provider type", idenityProviderType)
+	}
+
+	return data
 }
 
 func GenSecretLiteral(name string, clientSecret string, namespace string) *Secret {

--- a/ocp4/secrets/secrets_test.go
+++ b/ocp4/secrets/secrets_test.go
@@ -1,0 +1,83 @@
+package secrets
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenSecretFileHtpasswd(t *testing.T) {
+	htpasswdFile := "testfile1"
+	encoded := base64.StdEncoding.EncodeToString([]byte(htpasswdFile))
+	resSecret := GenSecretFile("htpasswd-test", encoded, "openshift-config", "htpasswd")
+
+	var data = HTPasswdFileSecret{HTPasswd: encoded}
+	var expectedSecret = Secret{
+		APIVersion: APIVersion,
+		Data:       data,
+		Kind:       "Secret",
+		Type:       "Opaque",
+		MetaData: MetaData{
+			Name:      "htpasswd-test",
+			Namespace: "openshift-config",
+		},
+	}
+
+	assert.Equal(t, &expectedSecret, resSecret)
+}
+func TestGenSecretFileKeystone(t *testing.T) {
+	keystoneFile := "testfile2"
+	encoded := base64.StdEncoding.EncodeToString([]byte(keystoneFile))
+	resSecret := GenSecretFile("keystone-test", encoded, "openshift-config", "keystone")
+
+	var data = KeystoneFileSecret{Keystone: encoded}
+	var expectedSecret = Secret{
+		APIVersion: APIVersion,
+		Data:       data,
+		Kind:       "Secret",
+		Type:       "Opaque",
+		MetaData: MetaData{
+			Name:      "keystone-test",
+			Namespace: "openshift-config",
+		},
+	}
+
+	assert.Equal(t, &expectedSecret, resSecret)
+}
+func TestGenSecretLiteral(t *testing.T) {
+	resSecret := GenSecretLiteral("literal-secret", "some-value", "openshift-config")
+
+	var data = LiteralSecret{ClientSecret: "some-value"}
+	var expectedSecret = Secret{
+		APIVersion: APIVersion,
+		Data:       data,
+		Kind:       "Secret",
+		Type:       "Opaque",
+		MetaData: MetaData{
+			Name:      "literal-secret",
+			Namespace: "openshift-config",
+		},
+	}
+
+	assert.Equal(t, &expectedSecret, resSecret)
+}
+
+func TestGenYaml(t *testing.T) {
+	var data = LiteralSecret{ClientSecret: "some-value"}
+	var secret = Secret{
+		APIVersion: APIVersion,
+		Data:       data,
+		Kind:       "Secret",
+		Type:       "Opaque",
+		MetaData: MetaData{
+			Name:      "literal-secret",
+			Namespace: "openshift-config",
+		},
+	}
+
+	yaml := secret.GenYAML()
+	expectedYaml := "apiVersion: v1\nkind: Secret\ntype: Opaque\nmetaData:\n  name: literal-secret\n  namespace: openshift-config\ndata:\n  clientSecret: some-value\n"
+
+	assert.Equal(t, expectedYaml, yaml)
+}

--- a/test/oauth/bulk-test-master-config.yaml
+++ b/test/oauth/bulk-test-master-config.yaml
@@ -49,6 +49,19 @@ oauthConfig:
       apiVersion: v1
       file: /etc/origin/master/htpasswd
       kind: HTPasswdPasswordIdentityProvider
+  - name: my_keystone_provider 
+    challenge: true 
+    login: true 
+    mappingMethod: claim 
+    provider:
+      apiVersion: v1
+      kind: KeystonePasswordIdentityProvider
+      domainName: default 
+      url: http://fake.url:5000
+      ca: keystone.pem 
+      certFile: clientcert.pem 
+      keyFile: clientkey.pem 
+      useKeystoneIdentity: false  
   - name: my_request_header_provider
     challenge: true
     login: true

--- a/test/oauth/keystone-test-master-config.yaml
+++ b/test/oauth/keystone-test-master-config.yaml
@@ -1,0 +1,28 @@
+oauthConfig:
+  assetPublicURL: https://openshift.gildub2.lab.pnq2.cee.redhat.com/console/
+  grantConfig:
+    method: auto
+  identityProviders:
+  - name: my_keystone_provider 
+    challenge: true 
+    login: true 
+    mappingMethod: claim 
+    provider:
+      apiVersion: v1
+      kind: KeystonePasswordIdentityProvider
+      domainName: default 
+      url: http://fake.url:5000
+      ca: keystone.pem 
+      certFile: clientcert.pem 
+      keyFile: clientkey.pem 
+      useKeystoneIdentity: false  
+  masterCA: ca-bundle.crt
+  masterPublicURL: https://openshift.gildub2.lab.pnq2.cee.redhat.com:443
+  masterURL: https://openshift.internal.gildub2.lab.pnq2.cee.redhat.com:443
+  sessionConfig:
+    sessionMaxAgeSeconds: 3600
+    sessionName: ssn
+    sessionSecretsFile: /etc/origin/master/session-secrets.yaml
+  tokenConfig:
+    accessTokenMaxAgeSeconds: 86400
+    authorizeTokenMaxAgeSeconds: 500


### PR DESCRIPTION
I made secret generation more flexible and covered it with tests.

Keystone auth misses file fetching, same as htpasswd now.