### PR TITLE
Manifests are dumped locally

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,7 +15,10 @@
 package cmd
 
 import (
+	"io/ioutil"
+	"os"
 	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/fusor/cpma/env"
@@ -59,7 +62,17 @@ var rootCmd = &cobra.Command{
 			mc := ocp3config.ParseMaster()
 			clusterV4 := ocp4.Cluster{}
 			clusterV4.Translate(mc)
-			clusterV4.GenYAML()
+			manifests := clusterV4.GenYAML()
+
+			// TODO: Add to pipeline as exit channel
+			for _, manifest := range manifests {
+				maniftestfile := filepath.Join(env.Config().GetString("OutputDir"), "manifests", manifest.Name)
+				os.MkdirAll(path.Dir(maniftestfile), 0755)
+				err := ioutil.WriteFile(maniftestfile, manifest.CRD, 0644)
+				if err != nil {
+					logrus.Panic(err)
+				}
+			}
 		}
 	},
 }

--- a/ocp4/oauth/oauth.go
+++ b/ocp4/oauth/oauth.go
@@ -104,11 +104,11 @@ func Translate(oauthconfig *configv1.OAuthConfig) (*OAuthCRD, []secrets.Secret, 
 }
 
 // GenYAML returns a YAML of the OAuthCRD
-func (oauth *OAuthCRD) GenYAML() string {
+func (oauth *OAuthCRD) GenYAML() []byte {
 	yamlBytes, err := yaml.Marshal(&oauth)
 	if err != nil {
 		logrus.Fatal(err)
 	}
 
-	return string(yamlBytes)
+	return yamlBytes
 }

--- a/ocp4/oauth/oauth_test.go
+++ b/ocp4/oauth/oauth_test.go
@@ -34,7 +34,7 @@ func TestGenYAML(t *testing.T) {
 	masterConfig := testConfig.ParseMaster()
 	crd, _, err := Translate(masterConfig.OAuthConfig)
 
-	yaml := crd.GenYAML()
+	CRD := crd.GenYAML()
 	expectedYaml := `apiVersion: config.openshift.io/v1
 kind: OAuth
 metaData:
@@ -52,5 +52,5 @@ spec:
         name: htpasswd_auth-secret
 `
 	require.NoError(t, err)
-	assert.Equal(t, expectedYaml, yaml)
+	assert.Equal(t, expectedYaml, string(CRD))
 }

--- a/ocp4/secrets/secrets.go
+++ b/ocp4/secrets/secrets.go
@@ -74,11 +74,11 @@ func buildData(secretType, secretContent string) interface{} {
 }
 
 // GenYAML returns a YAML of the OAuthCRD
-func (secret *Secret) GenYAML() string {
+func (secret *Secret) GenYAML() []byte {
 	yamlBytes, err := yaml.Marshal(&secret)
 	if err != nil {
 		logrus.WithError(err).Fatal("Cannot generate CRD")
 		logrus.Debugf("%+v", secret)
 	}
-	return string(yamlBytes)
+	return yamlBytes
 }

--- a/ocp4/secrets/secrets_test.go
+++ b/ocp4/secrets/secrets_test.go
@@ -2,6 +2,7 @@ package secrets
 
 import (
 	"encoding/base64"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -95,8 +96,8 @@ func TestGenYaml(t *testing.T) {
 		},
 	}
 
-	yaml := secret.GenYAML()
+	manifest := secret.GenYAML()
+	fmt.Println(fmt.Sprintf("%v", manifest))
 	expectedYaml := "apiVersion: v1\nkind: Secret\ntype: Opaque\nmetaData:\n  name: literal-secret\n  namespace: openshift-config\ndata:\n  clientSecret: some-value\n"
-
-	assert.Equal(t, expectedYaml, yaml)
+	assert.Equal(t, expectedYaml, string(manifest))
 }


### PR DESCRIPTION
CRD manifests need to be consumable by openshift-installer as locally generated YAML files

