### PR TITLE
Fix metada wrong case

### DIFF
--- a/ocp4/oauth/basicauth_test.go
+++ b/ocp4/oauth/basicauth_test.go
@@ -18,8 +18,8 @@ func TestTranslateMasterConfigBasicAuth(t *testing.T) {
 	var expectedCrd OAuthCRD
 	expectedCrd.APIVersion = "config.openshift.io/v1"
 	expectedCrd.Kind = "OAuth"
-	expectedCrd.MetaData.Name = "cluster"
-	expectedCrd.MetaData.NameSpace = "openshift-config"
+	expectedCrd.Metadata.Name = "cluster"
+	expectedCrd.Metadata.NameSpace = "openshift-config"
 
 	var basicAuthIDP identityProviderBasicAuth
 	basicAuthIDP.Type = "BasicAuth"

--- a/ocp4/oauth/github_test.go
+++ b/ocp4/oauth/github_test.go
@@ -18,8 +18,8 @@ func TestTranslateMasterConfigGithub(t *testing.T) {
 	var expectedCrd OAuthCRD
 	expectedCrd.APIVersion = "config.openshift.io/v1"
 	expectedCrd.Kind = "OAuth"
-	expectedCrd.MetaData.Name = "cluster"
-	expectedCrd.MetaData.NameSpace = "openshift-config"
+	expectedCrd.Metadata.Name = "cluster"
+	expectedCrd.Metadata.NameSpace = "openshift-config"
 
 	var githubIDP identityProviderGitHub
 	githubIDP.Type = "GitHub"

--- a/ocp4/oauth/gitlab_test.go
+++ b/ocp4/oauth/gitlab_test.go
@@ -18,8 +18,8 @@ func TestTranslateMasterConfigGitlab(t *testing.T) {
 	var expectedCrd OAuthCRD
 	expectedCrd.APIVersion = "config.openshift.io/v1"
 	expectedCrd.Kind = "OAuth"
-	expectedCrd.MetaData.Name = "cluster"
-	expectedCrd.MetaData.NameSpace = "openshift-config"
+	expectedCrd.Metadata.Name = "cluster"
+	expectedCrd.Metadata.NameSpace = "openshift-config"
 
 	var gitlabIDP identityProviderGitLab
 	gitlabIDP.Type = "GitLab"

--- a/ocp4/oauth/google_test.go
+++ b/ocp4/oauth/google_test.go
@@ -18,8 +18,8 @@ func TestTranslateMasterConfigGoogle(t *testing.T) {
 	var expectedCrd OAuthCRD
 	expectedCrd.APIVersion = "config.openshift.io/v1"
 	expectedCrd.Kind = "OAuth"
-	expectedCrd.MetaData.Name = "cluster"
-	expectedCrd.MetaData.NameSpace = "openshift-config"
+	expectedCrd.Metadata.Name = "cluster"
+	expectedCrd.Metadata.NameSpace = "openshift-config"
 
 	var googleIDP identityProviderGoogle
 	googleIDP.Type = "Google"

--- a/ocp4/oauth/htpasswd_test.go
+++ b/ocp4/oauth/htpasswd_test.go
@@ -18,8 +18,8 @@ func TestTranslateMasterConfigHtpasswd(t *testing.T) {
 	var expectedCrd OAuthCRD
 	expectedCrd.APIVersion = "config.openshift.io/v1"
 	expectedCrd.Kind = "OAuth"
-	expectedCrd.MetaData.Name = "cluster"
-	expectedCrd.MetaData.NameSpace = "openshift-config"
+	expectedCrd.Metadata.Name = "cluster"
+	expectedCrd.Metadata.NameSpace = "openshift-config"
 
 	var htpasswdIDP identityProviderHTPasswd
 	htpasswdIDP.Name = "htpasswd_auth"

--- a/ocp4/oauth/keystone_test.go
+++ b/ocp4/oauth/keystone_test.go
@@ -18,8 +18,8 @@ func TestTranslateMasterConfigKeystone(t *testing.T) {
 	var expectedCrd OAuthCRD
 	expectedCrd.APIVersion = "config.openshift.io/v1"
 	expectedCrd.Kind = "OAuth"
-	expectedCrd.MetaData.Name = "cluster"
-	expectedCrd.MetaData.NameSpace = "openshift-config"
+	expectedCrd.Metadata.Name = "cluster"
+	expectedCrd.Metadata.NameSpace = "openshift-config"
 
 	var keystoneIDP identityProviderKeystone
 	keystoneIDP.Type = "Keystone"

--- a/ocp4/oauth/ldap_test.go
+++ b/ocp4/oauth/ldap_test.go
@@ -18,8 +18,8 @@ func TestTranslateMasterConfigLDAP(t *testing.T) {
 	var expectedCrd OAuthCRD
 	expectedCrd.APIVersion = "config.openshift.io/v1"
 	expectedCrd.Kind = "OAuth"
-	expectedCrd.MetaData.Name = "cluster"
-	expectedCrd.MetaData.NameSpace = "openshift-config"
+	expectedCrd.Metadata.Name = "cluster"
+	expectedCrd.Metadata.NameSpace = "openshift-config"
 
 	var ldapIDP identityProviderLDAP
 	ldapIDP.Name = "my_ldap_provider"

--- a/ocp4/oauth/oauth.go
+++ b/ocp4/oauth/oauth.go
@@ -27,7 +27,7 @@ func init() {
 type OAuthCRD struct {
 	APIVersion string   `yaml:"apiVersion"`
 	Kind       string   `yaml:"kind"`
-	MetaData   MetaData `yaml:"metaData"`
+	Metadata   MetaData `yaml:"metadata"`
 	Spec       struct {
 		IdentityProviders []interface{} `yaml:"identityProviders"`
 	} `yaml:"spec"`
@@ -56,8 +56,8 @@ func Translate(oauthconfig *configv1.OAuthConfig) (*OAuthCRD, []secrets.Secret, 
 	var oauthCrd OAuthCRD
 	oauthCrd.APIVersion = APIVersion
 	oauthCrd.Kind = "OAuth"
-	oauthCrd.MetaData.Name = "cluster"
-	oauthCrd.MetaData.NameSpace = "openshift-config"
+	oauthCrd.Metadata.Name = "cluster"
+	oauthCrd.Metadata.NameSpace = "openshift-config"
 
 	var idP interface{}
 	var secretsSlice []secrets.Secret

--- a/ocp4/oauth/oauth_test.go
+++ b/ocp4/oauth/oauth_test.go
@@ -38,7 +38,7 @@ func TestGenYAML(t *testing.T) {
 	CRD := crd.GenYAML()
 	expectedYaml := `apiVersion: config.openshift.io/v1
 kind: OAuth
-metaData:
+metadata:
   name: cluster
   namespace: openshift-config
 spec:

--- a/ocp4/oauth/openid_test.go
+++ b/ocp4/oauth/openid_test.go
@@ -18,8 +18,8 @@ func TestTranslateMasterConfigOpenID(t *testing.T) {
 	var expectedCrd OAuthCRD
 	expectedCrd.APIVersion = "config.openshift.io/v1"
 	expectedCrd.Kind = "OAuth"
-	expectedCrd.MetaData.Name = "cluster"
-	expectedCrd.MetaData.NameSpace = "openshift-config"
+	expectedCrd.Metadata.Name = "cluster"
+	expectedCrd.Metadata.NameSpace = "openshift-config"
 
 	var openidIDP identityProviderOpenID
 	openidIDP.Type = "OpenID"

--- a/ocp4/oauth/requestheader_test.go
+++ b/ocp4/oauth/requestheader_test.go
@@ -18,8 +18,8 @@ func TestTranslateMasterConfigRequestHeader(t *testing.T) {
 	var expectedCrd OAuthCRD
 	expectedCrd.APIVersion = "config.openshift.io/v1"
 	expectedCrd.Kind = "OAuth"
-	expectedCrd.MetaData.Name = "cluster"
-	expectedCrd.MetaData.NameSpace = "openshift-config"
+	expectedCrd.Metadata.Name = "cluster"
+	expectedCrd.Metadata.NameSpace = "openshift-config"
 
 	var requestHeaderIDP identityProviderRequestHeader
 

--- a/ocp4/ocp4.go
+++ b/ocp4/ocp4.go
@@ -38,7 +38,7 @@ func (cluster *Cluster) GenYAML() []Manifest {
 	manifests = append(manifests, manifest)
 
 	for _, secret := range cluster.Master.Secrets {
-		filename := "CPMA-cluster-config-secret-" + secret.MetaData.Name + ".yaml"
+		filename := "CPMA-cluster-config-secret-" + secret.Metadata.Name + ".yaml"
 		m := Manifest{Name: filename, CRD: secret.GenYAML()}
 		manifests = append(manifests, m)
 	}

--- a/ocp4/ocp4_test.go
+++ b/ocp4/ocp4_test.go
@@ -16,12 +16,12 @@ func TestClusterTranslate(t *testing.T) {
 	clusterV4 := Cluster{}
 	clusterV4.Translate(parsedTestConfig)
 
-	assert.Equal(t, "cluster", clusterV4.Master.OAuth.MetaData.Name)
+	assert.Equal(t, "cluster", clusterV4.Master.OAuth.Metadata.Name)
 	assert.Equal(t, 2, len(clusterV4.Master.OAuth.Spec.IdentityProviders))
 
 	assert.Equal(t, 2, len(clusterV4.Master.Secrets))
-	assert.Equal(t, "htpasswd_auth-secret", clusterV4.Master.Secrets[0].MetaData.Name)
-	assert.Equal(t, "github123456789-secret", clusterV4.Master.Secrets[1].MetaData.Name)
+	assert.Equal(t, "htpasswd_auth-secret", clusterV4.Master.Secrets[0].Metadata.Name)
+	assert.Equal(t, "github123456789-secret", clusterV4.Master.Secrets[1].Metadata.Name)
 }
 
 func TestClusterGenYaml(t *testing.T) {
@@ -41,7 +41,7 @@ func TestClusterGenYaml(t *testing.T) {
 	// Test Oauth CR contents
 	expectedOauthCR := `apiVersion: config.openshift.io/v1
 kind: OAuth
-metaData:
+metadata:
   name: cluster
   namespace: openshift-config
 spec:
@@ -79,7 +79,7 @@ spec:
 	expectedSecretHtpasswd := `apiVersion: v1
 kind: Secret
 type: Opaque
-metaData:
+metadata:
   name: htpasswd_auth-secret
   namespace: openshift-config
 data:
@@ -89,7 +89,7 @@ data:
 	expectedSecretGitHub := `apiVersion: v1
 kind: Secret
 type: Opaque
-metaData:
+metadata:
   name: github123456789-secret
   namespace: openshift-config
 data:

--- a/ocp4/secrets/secrets.go
+++ b/ocp4/secrets/secrets.go
@@ -27,7 +27,7 @@ type Secret struct {
 	APIVersion string      `yaml:"apiVersion"`
 	Kind       string      `yaml:"kind"`
 	Type       string      `yaml:"type"`
-	MetaData   MetaData    `yaml:"metaData"`
+	Metadata   MetaData    `yaml:"metadata"`
 	Data       interface{} `yaml:"data"`
 }
 
@@ -46,7 +46,7 @@ func GenSecret(name string, secretContent string, namespace string, secretType s
 		Data:       data,
 		Kind:       "Secret",
 		Type:       "Opaque",
-		MetaData: MetaData{
+		Metadata: MetaData{
 			Name:      name,
 			Namespace: namespace,
 		},

--- a/ocp4/secrets/secrets_test.go
+++ b/ocp4/secrets/secrets_test.go
@@ -19,7 +19,7 @@ func TestGenSecretFileHtpasswd(t *testing.T) {
 		Data:       data,
 		Kind:       "Secret",
 		Type:       "Opaque",
-		MetaData: MetaData{
+		Metadata: MetaData{
 			Name:      "htpasswd-test",
 			Namespace: "openshift-config",
 		},
@@ -38,7 +38,7 @@ func TestGenSecretFileKeystone(t *testing.T) {
 		Data:       data,
 		Kind:       "Secret",
 		Type:       "Opaque",
-		MetaData: MetaData{
+		Metadata: MetaData{
 			Name:      "keystone-test",
 			Namespace: "openshift-config",
 		},
@@ -57,7 +57,7 @@ func TestGenSecretFileBasicAuth(t *testing.T) {
 		Data:       data,
 		Kind:       "Secret",
 		Type:       "Opaque",
-		MetaData: MetaData{
+		Metadata: MetaData{
 			Name:      "keystone-test",
 			Namespace: "openshift-config",
 		},
@@ -74,7 +74,7 @@ func TestGenSecretLiteral(t *testing.T) {
 		Data:       data,
 		Kind:       "Secret",
 		Type:       "Opaque",
-		MetaData: MetaData{
+		Metadata: MetaData{
 			Name:      "literal-secret",
 			Namespace: "openshift-config",
 		},
@@ -90,7 +90,7 @@ func TestGenYaml(t *testing.T) {
 		Data:       data,
 		Kind:       "Secret",
 		Type:       "Opaque",
-		MetaData: MetaData{
+		Metadata: MetaData{
 			Name:      "literal-secret",
 			Namespace: "openshift-config",
 		},
@@ -98,6 +98,6 @@ func TestGenYaml(t *testing.T) {
 
 	manifest := secret.GenYAML()
 	fmt.Println(fmt.Sprintf("%v", manifest))
-	expectedYaml := "apiVersion: v1\nkind: Secret\ntype: Opaque\nmetaData:\n  name: literal-secret\n  namespace: openshift-config\ndata:\n  clientSecret: some-value\n"
+	expectedYaml := "apiVersion: v1\nkind: Secret\ntype: Opaque\nmetadata:\n  name: literal-secret\n  namespace: openshift-config\ndata:\n  clientSecret: some-value\n"
 	assert.Equal(t, expectedYaml, string(manifest))
 }


### PR DESCRIPTION
Must be "Metadata" for Go and "metadata" for YAML but not MetaData and metaData respectively