### PR TITLE
Fetch xtra file

### DIFF
--- a/pkg/ocp4/oauth/htpasswd.go
+++ b/pkg/ocp4/oauth/htpasswd.go
@@ -2,10 +2,12 @@ package oauth
 
 import (
 	"encoding/base64"
+	"path/filepath"
 
-	"github.com/fusor/cpma/pkg/ocp4/secrets"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 
+	"github.com/fusor/cpma/env"
+	"github.com/fusor/cpma/pkg/ocp4/secrets"
 	configv1 "github.com/openshift/api/legacyconfig/v1"
 )
 
@@ -32,10 +34,13 @@ func buildHTPasswdIP(serializer *json.Serializer, p configv1.IdentityProvider) (
 
 	secretName := p.Name + "-secret"
 	idP.HTPasswd.FileData.Name = secretName
-	// Retrieve file
-	//htpasswdFile := Fetch_File(htpasswd.File)
-	htpasswdFile := "This is pretend content"
-	encoded := base64.StdEncoding.EncodeToString([]byte(htpasswdFile))
+
+	host := env.Config().GetString("Source")
+	src := filepath.Join(htpasswd.File)
+	dst := filepath.Join(env.Config().GetString("OutputDir"), host, htpasswd.File)
+	f := GetFile(host, src, dst)
+
+	encoded := base64.StdEncoding.EncodeToString(f)
 	secret := secrets.GenSecret(secretName, encoded, "openshift-config", "htpasswd")
 
 	return idP, *secret

--- a/pkg/ocp4/oauth/htpasswd_test.go
+++ b/pkg/ocp4/oauth/htpasswd_test.go
@@ -10,6 +10,9 @@ import (
 )
 
 func TestTranslateMasterConfigHtpasswd(t *testing.T) {
+	defer func() { GetFile = _GetFile }()
+	GetFile = mockGetFile
+
 	file := "testdata/htpasswd-test-master-config.yaml"
 	content, _ := ioutil.ReadFile(file)
 

--- a/pkg/ocp4/oauth/keystone.go
+++ b/pkg/ocp4/oauth/keystone.go
@@ -2,9 +2,11 @@ package oauth
 
 import (
 	"encoding/base64"
+	"path/filepath"
 
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 
+	"github.com/fusor/cpma/env"
 	"github.com/fusor/cpma/pkg/ocp4/secrets"
 	configv1 "github.com/openshift/api/legacyconfig/v1"
 )
@@ -43,15 +45,23 @@ func buildKeystoneIP(serializer *json.Serializer, p configv1.IdentityProvider) (
 	certSecretName := p.Name + "-client-cert-secret"
 	idP.Keystone.TLSClientCert.Name = certSecretName
 
-	// TODO: Fetch cert and key
-	certFile := "456This is pretend content"
+	outputDir := env.Config().GetString("OutputDir")
+	host := env.Config().GetString("Source")
+
+	src := filepath.Join(keystone.KeyFile)
+	dst := filepath.Join(outputDir, host, keystone.CertFile)
+	certFile := GetFile(host, src, dst)
+
 	encoded := base64.StdEncoding.EncodeToString([]byte(certFile))
 	certSecret := secrets.GenSecret(certSecretName, encoded, "openshift-config", "keystone")
 
 	keySecretName := p.Name + "-client-key-secret"
 	idP.Keystone.TLSClientKey.Name = keySecretName
 
-	keyFile := "123This is pretend content"
+	src = filepath.Join(keystone.KeyFile)
+	dst = filepath.Join(outputDir, host, keystone.KeyFile)
+	keyFile := GetFile(host, src, dst)
+
 	encoded = base64.StdEncoding.EncodeToString([]byte(keyFile))
 	keySecret := secrets.GenSecret(keySecretName, encoded, "openshift-config", "keystone")
 

--- a/pkg/ocp4/oauth/keystone_test.go
+++ b/pkg/ocp4/oauth/keystone_test.go
@@ -10,6 +10,9 @@ import (
 )
 
 func TestTranslateMasterConfigKeystone(t *testing.T) {
+	defer func() { GetFile = _GetFile }()
+	GetFile = mockGetFile
+
 	file := "testdata/keystone-test-master-config.yaml"
 	content, _ := ioutil.ReadFile(file)
 

--- a/pkg/ocp4/oauth/oauth.go
+++ b/pkg/ocp4/oauth/oauth.go
@@ -1,6 +1,9 @@
 package oauth
 
 import (
+	"io/ioutil"
+
+	"github.com/fusor/cpma/internal/sftpclient"
 	"github.com/fusor/cpma/pkg/ocp4/secrets"
 	configv1 "github.com/openshift/api/legacyconfig/v1"
 	oauthv1 "github.com/openshift/api/oauth/v1"
@@ -46,7 +49,20 @@ type MetaData struct {
 	NameSpace string `yaml:"namespace"`
 }
 
-var APIVersion = "config.openshift.io/v1"
+var (
+	APIVersion = "config.openshift.io/v1"
+	GetFile    = FetchFile
+)
+
+// FetchFile provides remote file retrieval
+func FetchFile(host, src, dst string) []byte {
+	sftpclient.Fetch(host, src, dst)
+	f, err := ioutil.ReadFile(dst)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+	return f
+}
 
 // Translate converts OCPv3 OAuth to OCPv4 OAuth Custom Resources
 func Translate(oauthconfig *configv1.OAuthConfig) (*OAuthCRD, []secrets.Secret, error) {

--- a/pkg/ocp4/oauth/oauth_test.go
+++ b/pkg/ocp4/oauth/oauth_test.go
@@ -10,7 +10,16 @@ import (
 	"github.com/fusor/cpma/pkg/ocp3"
 )
 
+var _GetFile = GetFile
+
+func mockGetFile(host, src, dst string) []byte {
+	return []byte("This is test file content")
+}
+
 func TestTranslateMasterConfig(t *testing.T) {
+	defer func() { GetFile = _GetFile }()
+	GetFile = mockGetFile
+
 	file := "testdata/bulk-test-master-config.yaml"
 	content, _ := ioutil.ReadFile(file)
 
@@ -31,6 +40,9 @@ func TestTranslateMasterConfig(t *testing.T) {
 }
 
 func TestGenYAML(t *testing.T) {
+	defer func() { GetFile = _GetFile }()
+	GetFile = mockGetFile
+
 	file := "testdata/htpasswd-test-master-config.yaml"
 	content, _ := ioutil.ReadFile(file)
 

--- a/pkg/ocp4/ocp4_test.go
+++ b/pkg/ocp4/ocp4_test.go
@@ -7,9 +7,19 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/fusor/cpma/pkg/ocp3"
+	"github.com/fusor/cpma/pkg/ocp4/oauth"
 )
 
+var _GetFile = oauth.GetFile
+
+func mockGetFile(a, b, c string) []byte {
+	return []byte("This is test file content")
+}
+
 func TestClusterTranslate(t *testing.T) {
+	defer func() { oauth.GetFile = _GetFile }()
+	oauth.GetFile = mockGetFile
+
 	masterV4 := Master{}
 	file := "../testdata/common-test-master-config.yaml"
 	content, _ := ioutil.ReadFile(file)
@@ -27,6 +37,9 @@ func TestClusterTranslate(t *testing.T) {
 }
 
 func TestClusterGenYaml(t *testing.T) {
+	defer func() { oauth.GetFile = _GetFile }()
+	oauth.GetFile = mockGetFile
+
 	masterV4 := Master{}
 	file := "../testdata/common-test-master-config.yaml"
 	content, _ := ioutil.ReadFile(file)
@@ -86,7 +99,7 @@ metadata:
   name: htpasswd_auth-secret
   namespace: openshift-config
 data:
-  htpasswd: VGhpcyBpcyBwcmV0ZW5kIGNvbnRlbnQ=
+  htpasswd: VGhpcyBpcyB0ZXN0IGZpbGUgY29udGVudA==
 `
 
 	expectedSecretGitHub := `apiVersion: v1


### PR DESCRIPTION
This is used for fetching any xtra file discovered when parsing config.

Initially used by htpasswd and keystone.

