### PR TITLE
Config files retrieved locally if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,40 @@ Flags:
 -o, --output-dir string   set the directory to store extracted configuration.
 ```
 
-You can find example config in `examples/` 
+You can find example config in `examples/`
 
 Example:
 
 ```console
 $ ./bin/cpma --config /path/to/config/.yml --debug
 ```
+
+# IO
+
+The data file structure looks like the following tree structure example.
+The cluster endpoints subfolders contain the configuration files retrieved and to process.
+The manifests directory contains the generated CRDs.
+
+data
+├── manifests
+├── master-0.example.com
+|   └── etc
+|       └── origin
+|           ├── master
+|               ├── htpasswd
+|               └── master-config.yaml
+└── node-1.example.com
+    └── etc
+        └── origin
+            └── node
+                └── node-config.yaml
+
+
+The configuration files are retrieved from local disk (outputDir/<Hostname>/),
+If a file is not available it's retrieved from <Hostname> and stored on local disk.
+
+To trigger a total or partial network file fetch, remove any prior data from <Hostname> sub directory.
+
 
 # Unit tests
 

--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -1,0 +1,27 @@
+package io
+
+import (
+	"io/ioutil"
+
+	"github.com/fusor/cpma/internal/io/sftpclient"
+	"github.com/sirupsen/logrus"
+)
+
+var GetFile = fetchFile
+
+// Fetch first tries to retrieve file from local disk (outputDir/<Hostname>/).
+// If it fails then connects to Hostname to retrieve file and stores it locally
+// To force a network connection remove outputDir/... prior to exec.
+func fetchFile(host, src, target string) []byte {
+	f, err := ioutil.ReadFile(target)
+	if err != nil {
+		sftpclient.Fetch(host, src, target)
+		netFile, err := ioutil.ReadFile(target)
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		return netFile
+	} else {
+		return f
+	}
+}

--- a/internal/io/sftpclient/sftpclient.go
+++ b/internal/io/sftpclient/sftpclient.go
@@ -108,5 +108,6 @@ func Fetch(hostname, src, dst string) {
 	if err != nil {
 		logrus.Fatal(err)
 	}
-	logrus.Printf("File %s:%s: %d bytes copied", hostname, src, bytes)
+
+	logrus.Printf("SFTP: %s:%s: %d bytes copied", hostname, src, bytes)
 }

--- a/pkg/ocp4/oauth/oauth.go
+++ b/pkg/ocp4/oauth/oauth.go
@@ -1,9 +1,7 @@
 package oauth
 
 import (
-	"io/ioutil"
-
-	"github.com/fusor/cpma/internal/sftpclient"
+	"github.com/fusor/cpma/internal/io"
 	"github.com/fusor/cpma/pkg/ocp4/secrets"
 	configv1 "github.com/openshift/api/legacyconfig/v1"
 	oauthv1 "github.com/openshift/api/oauth/v1"
@@ -51,18 +49,9 @@ type MetaData struct {
 
 var (
 	APIVersion = "config.openshift.io/v1"
-	GetFile    = FetchFile
+	// GetFile allows to mock file retrieval
+	GetFile = io.GetFile
 )
-
-// FetchFile provides remote file retrieval
-func FetchFile(host, src, dst string) []byte {
-	sftpclient.Fetch(host, src, dst)
-	f, err := ioutil.ReadFile(dst)
-	if err != nil {
-		logrus.Fatal(err)
-	}
-	return f
-}
 
 // Translate converts OCPv3 OAuth to OCPv4 OAuth Custom Resources
 func Translate(oauthconfig *configv1.OAuthConfig) (*OAuthCRD, []secrets.Secret, error) {

--- a/pkg/ocp4/oauth/oauth_test.go
+++ b/pkg/ocp4/oauth/oauth_test.go
@@ -7,10 +7,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/fusor/cpma/internal/io"
 	"github.com/fusor/cpma/pkg/ocp3"
 )
 
-var _GetFile = GetFile
+var _GetFile = io.GetFile
 
 func mockGetFile(host, src, dst string) []byte {
 	return []byte("This is test file content")


### PR DESCRIPTION
- Allows user to download cluster's configuration files and use them directly.
- Speeds up dev times

To force network file fetch just remove any prior data, for instance:
`rm -rf ./data/*`

Added to readme accordingly. 

Works around https://github.com/fusor/cpma/issues/31