### PR TITLE
Fix Makefile lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,9 @@ test: ## Test the project
 	GO111MODULE=on go test ./...
 
 lint: ## Run golint
-	@golint -set_exit_status $(addsuffix /... , $(SOURCE_DIRS))
+	@for i in $(SOURCE_DIRS); \
+		do golint -set_exit_status $(addprefix ./, $(addsuffix /... , $$i)); \
+		done
 
 fmt: ## Run go fmt
 	@gofmt -d $(SOURCES)


### PR DESCRIPTION
Using golang-1.12.2-1.fc30.x86_64 the existing lint command does not work.
I' would be curious to know if anyone using an older version finds this does or doesn't work for them.