### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ configuration of a OCP 3.x cluster to OCP 4.x
 
 ## Build
 
-Tested on go 1.12.4
+Requires go >= v1.11
 
 This project is Go Modules for managing dependencies. This means it can be
 cloned and compiled outside of `GOPATH`.


### PR DESCRIPTION
`make` won't build on go 1.10 (accidentally just tried, updating to 1.12.5 works, and I believe 1.11 does as well).