### PR TITLE
Log file fetch attempt before running GetFile

### DIFF
--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -113,8 +113,9 @@ func LoadConfig() Config {
 // Fetch files from the OCP3 cluster
 func (config *Config) Fetch(path string) []byte {
 	dst := filepath.Join(config.OutputDir, config.Hostname, path)
+	logrus.Infof("Fetching file: %s", dst)
 	f := GetFile(config.Hostname, path, dst)
-	logrus.Printf("File:Loaded: %s", dst)
+	logrus.Infof("File successfully loaded: %v", dst)
 
 	return f
 }


### PR DESCRIPTION
Should log the file we're attempting to Fetch prior to running GetFile. I was running this and it was trying to get a file that didn't exist, and I had no idea exactly what file was missing, because the error would tank the program before it logged the file.