### PR TITLE
Fix empty secret for basic auth

### DIFF
--- a/pkg/transform/oauth/oauth.go
+++ b/pkg/transform/oauth/oauth.go
@@ -89,6 +89,8 @@ const (
 	httpdAuthSecret = "htpasswd_auth-secret"
 	// httpProviderKind is the htpasswd idp type string
 	httpProviderKind = "HTPasswdPasswordIdentityProvider"
+	// basicAuthProviderKind is the basic auth idp type string
+	basicAuthProviderKind = "BasicAuthPasswordIdentityProvider"
 )
 
 // Translate converts OCPv3 OAuth to OCPv4 OAuth Custom Resources
@@ -143,7 +145,7 @@ func Translate(identityProviders []IdentityProvider) (*CRD, []secrets.Secret, er
 		}
 		oauthCrd.Spec.IdentityProviders = append(oauthCrd.Spec.IdentityProviders, idP)
 
-		if secret.Metadata.Name != httpdAuthSecret || p.Kind == httpProviderKind {
+		if (secret.Metadata.Name != httpdAuthSecret || p.Kind == httpProviderKind) && p.Kind != basicAuthProviderKind {
 			secretsSlice = append(secretsSlice, secret)
 		}
 	}

--- a/pkg/transform/oauth/oauth_test.go
+++ b/pkg/transform/oauth/oauth_test.go
@@ -106,6 +106,6 @@ func TestGenYAML(t *testing.T) {
 	CRD := crd.GenYAML()
 	expectedYaml, _ := ioutil.ReadFile("testdata/expected-bulk-test-masterconfig-oauth.yaml")
 
-	assert.Equal(t, 10, len(manifests))
+	assert.Equal(t, 9, len(manifests))
 	assert.Equal(t, expectedYaml, CRD)
 }


### PR DESCRIPTION
BasicAuth provider always creates an empty secret, this PR should fix.
The way how we handle empty secrets now maybe be improved, condition on line 148 can get bigger with time.
I believe we can accept this PR as a temporary fix and focus on more important translation logic.