### PR TITLE
Change transform.Type to transform.Name

### DIFF
--- a/pkg/transform/oauth_transform.go
+++ b/pkg/transform/oauth_transform.go
@@ -145,7 +145,7 @@ func (e OAuthExtraction) Validate() error {
 	return nil // Simulate fine
 }
 
-// Type retrurn transform type
-func (e OAuthTransform) Type() string {
+// Name returns a human readable name for the transform
+func (e OAuthTransform) Name() string {
 	return "OAuth"
 }

--- a/pkg/transform/registries_transform.go
+++ b/pkg/transform/registries_transform.go
@@ -107,7 +107,7 @@ func (e RegistriesExtraction) Validate() error {
 	return nil
 }
 
-// Type retrurn transform type
-func (e RegistriesTransform) Type() string {
+// Name returns a human readable name for the transform
+func (e RegistriesTransform) Name() string {
 	return "Registries"
 }

--- a/pkg/transform/sdn_transform.go
+++ b/pkg/transform/sdn_transform.go
@@ -177,7 +177,7 @@ func GenYAML(networkCR NetworkCR) ([]byte, error) {
 	return yamlBytes, nil
 }
 
-// Type retrurn transform type
-func (e SDNTransform) Type() string {
+// Name returns a human readable name for the transform
+func (e SDNTransform) Name() string {
 	return "SDN"
 }

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -55,7 +55,7 @@ type Extraction interface {
 // Transform is a generic transform
 type Transform interface {
 	Extract() (Extraction, error)
-	Type() string
+	Name() string
 }
 
 // Output is a generic output type
@@ -116,23 +116,23 @@ func (r Runner) Transform(transforms []Transform) {
 	for _, transform := range transforms {
 		extraction, err := transform.Extract()
 		if err != nil {
-			HandleError(err, transform.Type())
+			HandleError(err, transform.Name())
 			continue
 		}
 
 		if err := extraction.Validate(); err != nil {
-			HandleError(err, transform.Type())
+			HandleError(err, transform.Name())
 			continue
 		}
 
 		output, err := extraction.Transform()
 		if err != nil {
-			HandleError(err, transform.Type())
+			HandleError(err, transform.Name())
 			continue
 		}
 
 		if err := output.Flush(); err != nil {
-			HandleError(err, transform.Type())
+			HandleError(err, transform.Name())
 			continue
 		}
 	}


### PR DESCRIPTION
Having a method named `Type` suggests this might have something to do with actual data types. It's actually used as a method to provide a human readable identifier for an error string, so I think it makes sense to be more specific with the method name.