### PR TITLE
Added error propagation to oauth transform.

### DIFF
--- a/pkg/transform/oauth/github.go
+++ b/pkg/transform/oauth/github.go
@@ -26,11 +26,18 @@ type GitHub struct {
 }
 
 func buildGitHubIP(serializer *json.Serializer, p IdentityProvider) (IdentityProviderGitHub, secrets.Secret, error) {
-	var idP IdentityProviderGitHub
-	var secret *secrets.Secret
+	var (
+		err    error
+		idP    IdentityProviderGitHub
+		secret *secrets.Secret
 
-	var github configv1.GitHubIdentityProvider
-	_, _, _ = serializer.Decode(p.Provider.Raw, nil, &github)
+		github configv1.GitHubIdentityProvider
+	)
+
+	_, _, err = serializer.Decode(p.Provider.Raw, nil, &github)
+	if err != nil {
+		return idP, *secret, err
+	}
 
 	idP.Type = "GitHub"
 	idP.Name = p.Name
@@ -47,7 +54,7 @@ func buildGitHubIP(serializer *json.Serializer, p IdentityProvider) (IdentityPro
 	idP.GitHub.ClientSecret.Name = secretName
 
 	encoded := base64.StdEncoding.EncodeToString([]byte(github.ClientSecret.Value))
-	secret, err := secrets.GenSecret(secretName, encoded, "openshift-config", "literal")
+	secret, err = secrets.GenSecret(secretName, encoded, "openshift-config", "literal")
 	if err != nil {
 		return idP, *secret, err
 	}

--- a/pkg/transform/oauth/gitlab.go
+++ b/pkg/transform/oauth/gitlab.go
@@ -22,9 +22,16 @@ type GitLab struct {
 }
 
 func buildGitLabIP(serializer *json.Serializer, p IdentityProvider) (IdentityProviderGitLab, secrets.Secret, error) {
-	var idP IdentityProviderGitLab
-	var gitlab configv1.GitLabIdentityProvider
-	_, _, _ = serializer.Decode(p.Provider.Raw, nil, &gitlab)
+	var (
+		err    error
+		idP    IdentityProviderGitLab
+		gitlab configv1.GitLabIdentityProvider
+		secret *secrets.Secret
+	)
+	_, _, err = serializer.Decode(p.Provider.Raw, nil, &gitlab)
+	if err != nil {
+		return idP, *secret, err
+	}
 
 	idP.Type = "GitLab"
 	idP.Name = p.Name
@@ -37,7 +44,7 @@ func buildGitLabIP(serializer *json.Serializer, p IdentityProvider) (IdentityPro
 
 	secretName := p.Name + "-secret"
 	idP.GitLab.ClientSecret.Name = secretName
-	secret, err := secrets.GenSecret(secretName, gitlab.ClientSecret.Value, "openshift-config", "literal")
+	secret, err = secrets.GenSecret(secretName, gitlab.ClientSecret.Value, "openshift-config", "literal")
 	if err != nil {
 		return idP, *secret, err
 	}

--- a/pkg/transform/oauth/google.go
+++ b/pkg/transform/oauth/google.go
@@ -21,9 +21,16 @@ type Google struct {
 }
 
 func buildGoogleIP(serializer *json.Serializer, p IdentityProvider) (IdentityProviderGoogle, secrets.Secret, error) {
-	var idP IdentityProviderGoogle
-	var google configv1.GoogleIdentityProvider
-	_, _, _ = serializer.Decode(p.Provider.Raw, nil, &google)
+	var (
+		err    error
+		idP    IdentityProviderGoogle
+		google configv1.GoogleIdentityProvider
+		secret *secrets.Secret
+	)
+	_, _, err = serializer.Decode(p.Provider.Raw, nil, &google)
+	if err != nil {
+		return idP, *secret, err
+	}
 
 	idP.Type = "Google"
 	idP.Name = p.Name
@@ -35,7 +42,7 @@ func buildGoogleIP(serializer *json.Serializer, p IdentityProvider) (IdentityPro
 
 	secretName := p.Name + "-secret"
 	idP.Google.ClientSecret.Name = secretName
-	secret, err := secrets.GenSecret(secretName, google.ClientSecret.Value, "openshift-config", "literal")
+	secret, err = secrets.GenSecret(secretName, google.ClientSecret.Value, "openshift-config", "literal")
 	if err != nil {
 		return idP, *secret, err
 	}

--- a/pkg/transform/oauth/htpasswd.go
+++ b/pkg/transform/oauth/htpasswd.go
@@ -26,11 +26,16 @@ type FileData struct {
 }
 
 func buildHTPasswdIP(serializer *json.Serializer, p IdentityProvider) (IdentityProviderHTPasswd, secrets.Secret, error) {
+	var err error
 	var idP IdentityProviderHTPasswd
 	var secret *secrets.Secret
 
 	var htpasswd configv1.HTPasswdPasswordIdentityProvider
-	_, _, _ = serializer.Decode(p.Provider.Raw, nil, &htpasswd)
+
+	_, _, err = serializer.Decode(p.Provider.Raw, nil, &htpasswd)
+	if err != nil {
+		return idP, *secret, err
+	}
 
 	idP.Name = p.Name
 	idP.Type = "HTPasswd"
@@ -44,7 +49,7 @@ func buildHTPasswdIP(serializer *json.Serializer, p IdentityProvider) (IdentityP
 
 	encoded := base64.StdEncoding.EncodeToString(p.HTFileData)
 
-	secret, err := secrets.GenSecret(secretName, encoded, "openshift-config", "htpasswd")
+	secret, err = secrets.GenSecret(secretName, encoded, "openshift-config", "htpasswd")
 	if err != nil {
 		return idP, *secret, err
 	}

--- a/pkg/transform/oauth/keystone.go
+++ b/pkg/transform/oauth/keystone.go
@@ -33,7 +33,10 @@ func buildKeystoneIP(serializer *json.Serializer, p IdentityProvider) (IdentityP
 		keySecret  = new(secrets.Secret)
 		err        error
 	)
-	_, _, _ = serializer.Decode(p.Provider.Raw, nil, &keystone)
+	_, _, err = serializer.Decode(p.Provider.Raw, nil, &keystone)
+	if err != nil {
+		return idP, *certSecret, *keySecret, err
+	}
 
 	idP.Type = "Keystone"
 	idP.Name = p.Name

--- a/pkg/transform/oauth/ldap.go
+++ b/pkg/transform/oauth/ldap.go
@@ -30,10 +30,16 @@ type LDAPAttributes struct {
 	PreferredUsername []string `yaml:"preferredUsername"`
 }
 
-func buildLdapIP(serializer *json.Serializer, p IdentityProvider) IdentityProviderLDAP {
-	var idP IdentityProviderLDAP
-	var ldap configv1.LDAPPasswordIdentityProvider
-	_, _, _ = serializer.Decode(p.Provider.Raw, nil, &ldap)
+func buildLdapIP(serializer *json.Serializer, p IdentityProvider) (IdentityProviderLDAP, error) {
+	var (
+		err  error
+		idP  IdentityProviderLDAP
+		ldap configv1.LDAPPasswordIdentityProvider
+	)
+	_, _, err = serializer.Decode(p.Provider.Raw, nil, &ldap)
+	if err != nil {
+		return idP, err
+	}
 
 	idP.Type = "LDAP"
 	idP.Name = p.Name
@@ -49,5 +55,5 @@ func buildLdapIP(serializer *json.Serializer, p IdentityProvider) IdentityProvid
 	idP.LDAP.Insecure = ldap.Insecure
 	idP.LDAP.URL = ldap.URL
 
-	return idP
+	return idP, nil
 }

--- a/pkg/transform/oauth/oauth.go
+++ b/pkg/transform/oauth/oauth.go
@@ -123,9 +123,9 @@ func Translate(identityProviders []IdentityProvider) (*CRD, []secrets.Secret, er
 			idP, secret, err = buildOpenIDIP(serializer, p)
 			secretsSlice = append(secretsSlice, secret)
 		case "RequestHeaderIdentityProvider":
-			idP = buildRequestHeaderIP(serializer, p)
+			idP, err = buildRequestHeaderIP(serializer, p)
 		case "LDAPPasswordIdentityProvider":
-			idP = buildLdapIP(serializer, p)
+			idP, err = buildLdapIP(serializer, p)
 		case "KeystonePasswordIdentityProvider":
 			idP, certSecret, keySecret, err = buildKeystoneIP(serializer, p)
 			if certSecret != (secrets.Secret{}) {

--- a/pkg/transform/oauth/openid.go
+++ b/pkg/transform/oauth/openid.go
@@ -35,9 +35,16 @@ type OpenIDURLs struct {
 }
 
 func buildOpenIDIP(serializer *json.Serializer, p IdentityProvider) (IdentityProviderOpenID, secrets.Secret, error) {
-	var idP IdentityProviderOpenID
-	var openID configv1.OpenIDIdentityProvider
-	_, _, _ = serializer.Decode(p.Provider.Raw, nil, &openID)
+	var (
+		err    error
+		secret *secrets.Secret
+		idP    IdentityProviderOpenID
+		openID configv1.OpenIDIdentityProvider
+	)
+	_, _, err = serializer.Decode(p.Provider.Raw, nil, &openID)
+	if err != nil {
+		return idP, *secret, err
+	}
 
 	idP.Type = "OpenID"
 	idP.Name = p.Name
@@ -53,7 +60,7 @@ func buildOpenIDIP(serializer *json.Serializer, p IdentityProvider) (IdentityPro
 
 	secretName := p.Name + "-secret"
 	idP.OpenID.ClientSecret.Name = secretName
-	secret, err := secrets.GenSecret(secretName, openID.ClientSecret.Value, "openshift-config", "literal")
+	secret, err = secrets.GenSecret(secretName, openID.ClientSecret.Value, "openshift-config", "literal")
 	if err != nil {
 		return idP, *secret, err
 	}

--- a/pkg/transform/oauth/requestheader.go
+++ b/pkg/transform/oauth/requestheader.go
@@ -24,10 +24,16 @@ type RequestHeader struct {
 	PreferredUsernameHeaders []string `yaml:"preferredUsernameHeaders"`
 }
 
-func buildRequestHeaderIP(serializer *json.Serializer, p IdentityProvider) IdentityProviderRequestHeader {
-	var idP IdentityProviderRequestHeader
-	var requestHeader configv1.RequestHeaderIdentityProvider
-	_, _, _ = serializer.Decode(p.Provider.Raw, nil, &requestHeader)
+func buildRequestHeaderIP(serializer *json.Serializer, p IdentityProvider) (IdentityProviderRequestHeader, error) {
+	var (
+		err           error
+		idP           IdentityProviderRequestHeader
+		requestHeader configv1.RequestHeaderIdentityProvider
+	)
+	_, _, err = serializer.Decode(p.Provider.Raw, nil, &requestHeader)
+	if err != nil {
+		return idP, err
+	}
 
 	idP.Type = "RequestHeader"
 	idP.Name = p.Name
@@ -43,5 +49,5 @@ func buildRequestHeaderIP(serializer *json.Serializer, p IdentityProvider) Ident
 	idP.RequestHeader.NameHeaders = requestHeader.NameHeaders
 	idP.RequestHeader.PreferredUsernameHeaders = requestHeader.PreferredUsernameHeaders
 
-	return idP
+	return idP, nil
 }


### PR DESCRIPTION
Closes #157 

Changes:
* Error processing in all oauth transform files.
* Some variable regrouping, adding error propagation to `buildRequestHeaderIP` and `buildLdapIP`.