### PR TITLE
Make io.GetFile pure func and remove unused mock

### DIFF
--- a/pkg/io/io.go
+++ b/pkg/io/io.go
@@ -6,13 +6,10 @@ import (
 	"github.com/fusor/cpma/pkg/io/sftpclient"
 )
 
-// GetFile allows to mock file retrieval
-var GetFile = fetchFile
-
-// Fetch first tries to retrieve file from local disk (outputDir/<Hostname>/).
+// GetFile first tries to retrieve file from local disk (outputDir/<Hostname>/).
 // If it fails then connects to Hostname to retrieve file and stores it locally
 // To force a network connection remove outputDir/... prior to exec.
-func fetchFile(host, src, target string) ([]byte, error) {
+var GetFile = func(host, src, target string) ([]byte, error) {
 	f, err := ioutil.ReadFile(target)
 	if err != nil {
 		sftpclient.Fetch(host, src, target)

--- a/pkg/transform/oauth/htpasswd_test.go
+++ b/pkg/transform/oauth/htpasswd_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/fusor/cpma/pkg/io"
 	"github.com/fusor/cpma/pkg/transform/oauth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,9 +15,6 @@ import (
 )
 
 func TestTransformMasterConfigHtpasswd(t *testing.T) {
-	defer func() { io.GetFile = _GetFile }()
-	oauth.GetFile = mockGetFile
-
 	file := "testdata/htpasswd-test-master-config.yaml"
 
 	content, err := ioutil.ReadFile(file)

--- a/pkg/transform/oauth/keystone_test.go
+++ b/pkg/transform/oauth/keystone_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/fusor/cpma/pkg/io"
 	"github.com/fusor/cpma/pkg/transform/oauth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,9 +15,6 @@ import (
 )
 
 func TestTransformMasterConfigKeystone(t *testing.T) {
-	defer func() { io.GetFile = _GetFile }()
-	oauth.GetFile = mockGetFile
-
 	file := "testdata/keystone-test-master-config.yaml"
 
 	content, err := ioutil.ReadFile(file)

--- a/pkg/transform/oauth/oauth.go
+++ b/pkg/transform/oauth/oauth.go
@@ -1,7 +1,6 @@
 package oauth
 
 import (
-	"github.com/fusor/cpma/pkg/io"
 	"github.com/fusor/cpma/pkg/transform/secrets"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
@@ -78,12 +77,8 @@ type IdentityProvider struct {
 	UseAsLogin      bool
 }
 
-var (
-	// APIVersion is the apiVersion string
-	APIVersion = "config.openshift.io/v1"
-	// GetFile allows to mock file retrieval
-	GetFile = io.GetFile
-)
+// APIVersion is the apiVersion string
+var APIVersion = "config.openshift.io/v1"
 
 // Translate converts OCPv3 OAuth to OCPv4 OAuth Custom Resources
 func Translate(identityProviders []IdentityProvider) (*CRD, []secrets.Secret, error) {

--- a/pkg/transform/oauth/oauth_test.go
+++ b/pkg/transform/oauth/oauth_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/fusor/cpma/pkg/io"
 	"github.com/fusor/cpma/pkg/transform/oauth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,16 +14,7 @@ import (
 	k8sjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
-var _GetFile = io.GetFile
-
-func mockGetFile(a, b, c string) ([]byte, error) {
-	return []byte("This is test file content"), nil
-}
-
 func TestTransformMasterConfig(t *testing.T) {
-	defer func() { io.GetFile = _GetFile }()
-	oauth.GetFile = mockGetFile
-
 	file := "testdata/bulk-test-master-config.yaml"
 
 	content, err := ioutil.ReadFile(file)
@@ -87,9 +77,6 @@ func TestTransformMasterConfig(t *testing.T) {
 }
 
 func TestGenYAML(t *testing.T) {
-	defer func() { oauth.GetFile = _GetFile }()
-	oauth.GetFile = mockGetFile
-
 	file := "testdata/bulk-test-master-config.yaml"
 
 	content, err := ioutil.ReadFile(file)


### PR DESCRIPTION
The tests doen't make use of the mock function. 
Meanwhile we can still override io.GetFile if needed in the future.