### PR TITLE
Added ommiting optional headers from RequestHeader

### DIFF
--- a/pkg/transform/oauth/requestheader.go
+++ b/pkg/transform/oauth/requestheader.go
@@ -20,9 +20,9 @@ type RequestHeader struct {
 	CA                       *CA      `yaml:"ca,omitempty"`
 	ClientCommonNames        []string `yaml:"сlientCommonNames,omitempty"`
 	Headers                  []string `yaml:"headers"`
-	EmailHeaders             []string `yaml:"emailHeaders"`
-	NameHeaders              []string `yaml:"nameHeaders"`
-	PreferredUsernameHeaders []string `yaml:"preferredUsernameHeaders"`
+	EmailHeaders             []string `yaml:"emailHeaders,omitempty"`
+	NameHeaders              []string `yaml:"nameHeaders,omitempty"`
+	PreferredUsernameHeaders []string `yaml:"preferredUsernameHeaders,omitempty"`
 }
 
 func buildRequestHeaderIP(serializer *json.Serializer, p IdentityProvider) (*IdentityProviderRequestHeader, *configmaps.ConfigMap, error) {

--- a/pkg/transform/oauth/testdata/expected-omit-empty-masterconfig-oauth.yaml
+++ b/pkg/transform/oauth/testdata/expected-omit-empty-masterconfig-oauth.yaml
@@ -82,12 +82,6 @@ spec:
       headers:
       - X-Remote-User
       - SSO-User
-      emailHeaders:
-      - X-Remote-User-Email
-      nameHeaders:
-      - X-Remote-User-Display-Name
-      preferredUsernameHeaders:
-      - X-Remote-User-Login
   - name: my_openid_connect
     challenge: false
     login: true

--- a/pkg/transform/oauth/testdata/omit-empty-master-config.yaml
+++ b/pkg/transform/oauth/testdata/omit-empty-master-config.yaml
@@ -86,12 +86,6 @@ oauthConfig:
       headers:
       - X-Remote-User
       - SSO-User
-      emailHeaders:
-      - X-Remote-User-Email
-      nameHeaders:
-      - X-Remote-User-Display-Name
-      preferredUsernameHeaders:
-      - X-Remote-User-Login
   - name: my_openid_connect
     challenge: false
     login: true


### PR DESCRIPTION
EmailHeaders, NameHeaders and PrefferedUsernameHeaders were changed to optional, as it is stated in https://docs.openshift.com/container-platform/3.11/install_config/configuring_authentication.html#RequestHeaderIdentityProvider