### PR TITLE
Handle env, file and inline values of a secret

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/fusor/cpma/pkg/io/sftpclient"
 	"path/filepath"
 
 	"github.com/fusor/cpma/pkg/env"
@@ -28,6 +29,17 @@ func (c *Config) Fetch(path string) ([]byte, error) {
 	logrus.Infof("File:loaded: %v", dst)
 
 	return f, nil
+}
+
+// Env Fetch env vars from the OCP3 cluster
+func (c *Config) Env(envVar string) (string, error) {
+	output, err := sftpclient.GetEnvVar(c.Hostname, envVar)
+	if err != nil {
+		return "", err
+	}
+	logrus.Infof("Env:loaded: %s", output)
+
+	return output, nil
 }
 
 // LoadConfig collects and stores configuration for CPMA

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,13 +31,13 @@ func (c *Config) Fetch(path string) ([]byte, error) {
 	return f, nil
 }
 
-// Env Fetch env vars from the OCP3 cluster
-func (c *Config) Env(envVar string) (string, error) {
+// FetchEnv Fetch env vars from the OCP3 cluster
+func (c *Config) FetchEnv(envVar string) (string, error) {
 	output, err := sftpclient.GetEnvVar(c.Hostname, envVar)
 	if err != nil {
 		return "", err
 	}
-	logrus.Infof("Env:loaded: %s", output)
+	logrus.Debugf("Env:loaded: %s", envVar)
 
 	return output, nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"github.com/fusor/cpma/pkg/io/sftpclient"
 	"path/filepath"
 
 	"github.com/fusor/cpma/pkg/env"
@@ -29,17 +28,6 @@ func (c *Config) Fetch(path string) ([]byte, error) {
 	logrus.Infof("File:loaded: %v", dst)
 
 	return f, nil
-}
-
-// FetchEnv Fetch env vars from the OCP3 cluster
-func (c *Config) FetchEnv(envVar string) (string, error) {
-	output, err := sftpclient.GetEnvVar(c.Hostname, envVar)
-	if err != nil {
-		return "", err
-	}
-	logrus.Debugf("Env:loaded: %s", envVar)
-
-	return output, nil
 }
 
 // LoadConfig collects and stores configuration for CPMA

--- a/pkg/io/io.go
+++ b/pkg/io/io.go
@@ -3,7 +3,7 @@ package io
 import (
 	"io/ioutil"
 
-	"github.com/fusor/cpma/pkg/io/sftpclient"
+	"github.com/fusor/cpma/pkg/io/remotehost"
 	"github.com/sirupsen/logrus"
 )
 
@@ -13,7 +13,7 @@ import (
 var GetFile = func(host, src, target string) ([]byte, error) {
 	f, err := ioutil.ReadFile(target)
 	if err != nil {
-		sftpclient.Fetch(host, src, target)
+		remotehost.Fetch(host, src, target)
 		netFile, err := ioutil.ReadFile(target)
 		if err != nil {
 			return nil, err
@@ -25,7 +25,7 @@ var GetFile = func(host, src, target string) ([]byte, error) {
 
 // FetchEnv Fetch env vars from the OCP3 cluster
 func FetchEnv(host, envVar string) (string, error) {
-	output, err := sftpclient.GetEnvVar(host, envVar)
+	output, err := remotehost.GetEnvVar(host, envVar)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/io/io.go
+++ b/pkg/io/io.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 
 	"github.com/fusor/cpma/pkg/io/sftpclient"
+	"github.com/sirupsen/logrus"
 )
 
 // GetFile first tries to retrieve file from local disk (outputDir/<Hostname>/).
@@ -20,4 +21,15 @@ var GetFile = func(host, src, target string) ([]byte, error) {
 		return netFile, nil
 	}
 	return f, nil
+}
+
+// FetchEnv Fetch env vars from the OCP3 cluster
+func FetchEnv(host, envVar string) (string, error) {
+	output, err := sftpclient.GetEnvVar(host, envVar)
+	if err != nil {
+		return "", err
+	}
+	logrus.Debugf("Env:loaded: %s", envVar)
+
+	return output, nil
 }

--- a/pkg/io/remotehost/remotehost.go
+++ b/pkg/io/remotehost/remotehost.go
@@ -1,4 +1,4 @@
-package sftpclient
+package remotehost
 
 import (
 	"errors"

--- a/pkg/io/sftpclient/sftpclient.go
+++ b/pkg/io/sftpclient/sftpclient.go
@@ -162,7 +162,7 @@ func GetEnvVar(hostname, envVar string) (string, error) {
 		return "", err
 	}
 
-	cmd := "printf $" + envVar
+	cmd := fmt.Sprintf("print $%s", envVar)
 	output, err := session.Output(cmd)
 	if err != nil {
 		return "", err

--- a/pkg/io/sftpclient/sftpclient.go
+++ b/pkg/io/sftpclient/sftpclient.go
@@ -23,21 +23,21 @@ type Client struct {
 	*sftp.Client
 }
 
-// NewClient creates a new SFTP client
-func NewClient(source string) (Client, error) {
+// CreateConnection create ssh connection
+func CreateConnection(source string) (*ssh.Client, error) {
 	sshCreds := env.Config().GetStringMapString("SSHCreds")
 
 	key, err := ioutil.ReadFile(sshCreds["privatekey"])
 	if err != nil {
 		logrus.Errorf("Unable to read private key: %s", sshCreds["privatekey"])
-		return Client{}, err
+		return nil, err
 	}
 
 	// Create the Signer for this private key.
 	signer, err := ssh.ParsePrivateKey(key)
 	if err != nil {
 		logrus.Error("Unable to parse private key")
-		return Client{}, err
+		return nil, err
 	}
 
 	knownHostsFile := filepath.Join(env.Config().GetString("home"), ".ssh", "known_hosts")
@@ -45,7 +45,7 @@ func NewClient(source string) (Client, error) {
 	hostKeyCallback, err := kh.New(knownHostsFile)
 	if err != nil {
 		logrus.Errorf("Unable to get hostkey in %s", knownHostsFile)
-		return Client{}, err
+		return nil, err
 	}
 
 	sshConfig := &ssh.ClientConfig{
@@ -62,27 +62,53 @@ func NewClient(source string) (Client, error) {
 	if p := sshCreds["port"]; p != "" {
 		port, err = strconv.Atoi(p)
 		if err != nil || port < 1 || port > 65535 {
-			return Client{}, errors.New("Port number " + p + " is wrong.")
+			return nil, errors.New("Port number " + p + " is wrong.")
 		}
 	}
 
 	addr := fmt.Sprintf("%s:%d", source, port)
-	logrus.Debug("Connecting to", addr)
+	logrus.Debugf("Connecting to %s", addr)
 
 	connection, err := ssh.Dial("tcp", addr, sshConfig)
 	if err != nil {
 		logrus.Errorf("Cannot connect to %s", addr)
-		return Client{}, err
+		return nil, err
+	}
+
+	return connection, nil
+}
+
+// NewClient creates a new SFTP client
+func NewClient(source string) (*Client, error) {
+	connection, err := CreateConnection(source)
+	if err != nil {
+		return nil, err
 	}
 
 	// create new SFTP client
 	client, err := sftp.NewClient(connection)
 	if err != nil {
 		logrus.Error("Unable to create new SFTP client")
-		return Client{}, err
+		return nil, err
 	}
 
-	return Client{client}, nil
+	return &Client{client}, nil
+}
+
+// NewSSHSession Start new ssh session
+func NewSSHSession(source string) (*ssh.Session, error) {
+	connection, err := CreateConnection(source)
+	if err != nil {
+		return nil, err
+	}
+
+	session, err := connection.NewSession()
+	if err != nil {
+		logrus.Errorf("Cannot start session")
+		return nil, err
+	}
+
+	return session, nil
 }
 
 // GetFile copies source file to destination file
@@ -127,4 +153,20 @@ func Fetch(hostname, src, dst string) error {
 
 	logrus.Printf("SFTP: %s:%s: %d bytes copied", hostname, src, bytes)
 	return nil
+}
+
+// GetEnvVar get env var from remote host
+func GetEnvVar(hostname, envVar string) (string, error) {
+	session, err := NewSSHSession(hostname)
+	if err != nil {
+		return "", err
+	}
+
+	cmd := "printf $" + envVar
+	output, err := session.Output(cmd)
+	if err != nil {
+		return "", err
+	}
+
+	return string(output), nil
 }

--- a/pkg/transform/oauth/basicauth.go
+++ b/pkg/transform/oauth/basicauth.go
@@ -6,9 +6,8 @@ import (
 
 	"github.com/fusor/cpma/pkg/transform/configmaps"
 	"github.com/fusor/cpma/pkg/transform/secrets"
-	"k8s.io/apimachinery/pkg/runtime/serializer/json"
-
 	configv1 "github.com/openshift/api/legacyconfig/v1"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
 // IdentityProviderBasicAuth is a basic auth specific identity provider

--- a/pkg/transform/oauth/basicauth_test.go
+++ b/pkg/transform/oauth/basicauth_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/fusor/cpma/pkg/config"
 	"github.com/fusor/cpma/pkg/transform/oauth"
 	cpmatest "github.com/fusor/cpma/pkg/utils/test"
 	"github.com/stretchr/testify/assert"
@@ -11,6 +12,7 @@ import (
 )
 
 func TestTransformMasterConfigBasicAuth(t *testing.T) {
+	config := config.LoadConfig()
 	identityProviders, err := cpmatest.LoadIPTestData("testdata/basicauth/test-master-config.yaml")
 	require.NoError(t, err)
 
@@ -45,7 +47,7 @@ func TestTransformMasterConfigBasicAuth(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resCrd, _, _, err := oauth.Translate(identityProviders)
+			resCrd, _, _, err := oauth.Translate(identityProviders, &config)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedCrd, resCrd)
 		})

--- a/pkg/transform/oauth/github.go
+++ b/pkg/transform/oauth/github.go
@@ -1,6 +1,7 @@
 package oauth
 
 import (
+	"github.com/fusor/cpma/pkg/config"
 	"encoding/base64"
 	"errors"
 
@@ -27,7 +28,7 @@ type GitHub struct {
 	Teams         []string     `yaml:"teams,omitempty"`
 }
 
-func buildGitHubIP(serializer *json.Serializer, p IdentityProvider) (*IdentityProviderGitHub, *secrets.Secret, *configmaps.ConfigMap, error) {
+func buildGitHubIP(serializer *json.Serializer, p IdentityProvider, config *config.Config) (*IdentityProviderGitHub, *secrets.Secret, *configmaps.ConfigMap, error) {
 	var (
 		err         error
 		idP         = &IdentityProviderGitHub{}
@@ -58,8 +59,9 @@ func buildGitHubIP(serializer *json.Serializer, p IdentityProvider) (*IdentityPr
 
 	secretName := p.Name + "-secret"
 	idP.GitHub.ClientSecret.Name = secretName
+	secretContent, err := fetchStringSource(github.ClientSecret, config)
 
-	encoded := base64.StdEncoding.EncodeToString([]byte(github.ClientSecret.Value))
+	encoded := base64.StdEncoding.EncodeToString([]byte(secretContent))
 	secret, err = secrets.GenSecret(secretName, encoded, OAuthNamespace, secrets.LiteralSecretType)
 	if err != nil {
 		return nil, nil, nil, err

--- a/pkg/transform/oauth/github.go
+++ b/pkg/transform/oauth/github.go
@@ -1,15 +1,14 @@
 package oauth
 
 import (
-	"github.com/fusor/cpma/pkg/config"
 	"encoding/base64"
 	"errors"
 
+	"github.com/fusor/cpma/pkg/config"
 	"github.com/fusor/cpma/pkg/transform/configmaps"
 	"github.com/fusor/cpma/pkg/transform/secrets"
-	"k8s.io/apimachinery/pkg/runtime/serializer/json"
-
 	configv1 "github.com/openshift/api/legacyconfig/v1"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
 //IdentityProviderGitHub is a Github specific identity provider

--- a/pkg/transform/oauth/github.go
+++ b/pkg/transform/oauth/github.go
@@ -85,6 +85,10 @@ func validateGithubProvider(serializer *json.Serializer, p IdentityProvider) err
 		return err
 	}
 
+	if github.ClientSecret.KeyFile != "" {
+		return errors.New("Usage of encrypted files as secret value is not supported")
+	}
+
 	if err := validateClientData(github.ClientID, github.ClientSecret); err != nil {
 		return err
 	}

--- a/pkg/transform/oauth/github_test.go
+++ b/pkg/transform/oauth/github_test.go
@@ -91,6 +91,12 @@ func TestGithubValidation(t *testing.T) {
 			inputFile:    "testdata/github/invalid-clientsecret-master-config.yaml",
 			expectedErr:  errors.New("Client Secret can't be empty"),
 		},
+		{
+			name:         "fail if key file is present for client secret in github provider",
+			requireError: true,
+			inputFile:    "testdata/github/invalid-keyfile-master-config.yaml",
+			expectedErr:  errors.New("Usage of encrypted files as secret value is not supported"),
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/transform/oauth/github_test.go
+++ b/pkg/transform/oauth/github_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/fusor/cpma/pkg/config"
 	"github.com/fusor/cpma/pkg/transform/oauth"
 	cpmatest "github.com/fusor/cpma/pkg/utils/test"
 	"github.com/stretchr/testify/assert"
@@ -11,6 +12,7 @@ import (
 )
 
 func TestTransformMasterConfigGithub(t *testing.T) {
+	config := config.LoadConfig()
 	identityProviders, err := cpmatest.LoadIPTestData("testdata/github/test-master-config.yaml")
 	require.NoError(t, err)
 
@@ -46,7 +48,7 @@ func TestTransformMasterConfigGithub(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resCrd, _, _, err := oauth.Translate(identityProviders)
+			resCrd, _, _, err := oauth.Translate(identityProviders, &config)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedCrd, resCrd)
 		})

--- a/pkg/transform/oauth/gitlab.go
+++ b/pkg/transform/oauth/gitlab.go
@@ -84,6 +84,10 @@ func validateGitLabProvider(serializer *json.Serializer, p IdentityProvider) err
 		return errors.New("URL can't be empty")
 	}
 
+	if gitlab.ClientSecret.KeyFile != "" {
+		return errors.New("Usage of encrypted files as secret value is not supported")
+	}
+
 	if err := validateClientData(gitlab.ClientID, gitlab.ClientSecret); err != nil {
 		return err
 	}

--- a/pkg/transform/oauth/gitlab.go
+++ b/pkg/transform/oauth/gitlab.go
@@ -7,9 +7,8 @@ import (
 	"github.com/fusor/cpma/pkg/config"
 	"github.com/fusor/cpma/pkg/transform/configmaps"
 	"github.com/fusor/cpma/pkg/transform/secrets"
-	"k8s.io/apimachinery/pkg/runtime/serializer/json"
-
 	configv1 "github.com/openshift/api/legacyconfig/v1"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
 // IdentityProviderGitLab is a Gitlab specific identity provider

--- a/pkg/transform/oauth/gitlab.go
+++ b/pkg/transform/oauth/gitlab.go
@@ -54,7 +54,7 @@ func buildGitLabIP(serializer *json.Serializer, p IdentityProvider, config *conf
 
 	secretName := p.Name + "-secret"
 	idP.GitLab.ClientSecret.Name = secretName
-	secretContent, err := fetchSecret(gitlab.ClientSecret, config)
+	secretContent, err := fetchStringSource(gitlab.ClientSecret, config)
 
 	encoded := base64.StdEncoding.EncodeToString([]byte(secretContent))
 	secret, err = secrets.GenSecret(secretName, encoded, OAuthNamespace, secrets.LiteralSecretType)

--- a/pkg/transform/oauth/gitlab_test.go
+++ b/pkg/transform/oauth/gitlab_test.go
@@ -95,6 +95,12 @@ func TestGitlabValidation(t *testing.T) {
 			inputFile:    "testdata/gitlab/invalid-clientsecret-master-config.yaml",
 			expectedErr:  errors.New("Client Secret can't be empty"),
 		},
+		{
+			name:         "fail if key file is present for client secret in gitlab provider",
+			requireError: true,
+			inputFile:    "testdata/gitlab/invalid-keyfile-master-config.yaml",
+			expectedErr:  errors.New("Usage of encrypted files as secret value is not supported"),
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/transform/oauth/gitlab_test.go
+++ b/pkg/transform/oauth/gitlab_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/fusor/cpma/pkg/config"
 	"github.com/fusor/cpma/pkg/transform/oauth"
 	cpmatest "github.com/fusor/cpma/pkg/utils/test"
 	"github.com/stretchr/testify/assert"
@@ -11,6 +12,7 @@ import (
 )
 
 func TestTransformMasterConfigGitlab(t *testing.T) {
+	config := config.LoadConfig()
 	identityProviders, err := cpmatest.LoadIPTestData("testdata/gitlab/test-master-config.yaml")
 	require.NoError(t, err)
 
@@ -44,7 +46,7 @@ func TestTransformMasterConfigGitlab(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resCrd, _, _, err := oauth.Translate(identityProviders)
+			resCrd, _, _, err := oauth.Translate(identityProviders, &config)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedCrd, resCrd)
 		})

--- a/pkg/transform/oauth/google.go
+++ b/pkg/transform/oauth/google.go
@@ -72,6 +72,10 @@ func validateGoogleProvider(serializer *json.Serializer, p IdentityProvider) err
 		return err
 	}
 
+	if google.ClientSecret.KeyFile != "" {
+		return errors.New("Usage of encrypted files as secret value is not supported")
+	}
+
 	if err := validateClientData(google.ClientID, google.ClientSecret); err != nil {
 		return err
 	}

--- a/pkg/transform/oauth/google.go
+++ b/pkg/transform/oauth/google.go
@@ -1,11 +1,12 @@
 package oauth
 
 import (
+	"encoding/base64"
 	"errors"
 
 	"github.com/fusor/cpma/pkg/transform/secrets"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
-
+	"github.com/fusor/cpma/pkg/config"
 	configv1 "github.com/openshift/api/legacyconfig/v1"
 )
 
@@ -22,7 +23,7 @@ type Google struct {
 	HostedDomain string       `yaml:"hostedDomain,omitempty"`
 }
 
-func buildGoogleIP(serializer *json.Serializer, p IdentityProvider) (*IdentityProviderGoogle, *secrets.Secret, error) {
+func buildGoogleIP(serializer *json.Serializer, p IdentityProvider, config *config.Config) (*IdentityProviderGoogle, *secrets.Secret, error) {
 	var (
 		err    error
 		idP    = &IdentityProviderGoogle{}
@@ -44,7 +45,10 @@ func buildGoogleIP(serializer *json.Serializer, p IdentityProvider) (*IdentityPr
 
 	secretName := p.Name + "-secret"
 	idP.Google.ClientSecret.Name = secretName
-	secret, err = secrets.GenSecret(secretName, google.ClientSecret.Value, OAuthNamespace, secrets.LiteralSecretType)
+	secretContent, err := fetchStringSource(google.ClientSecret, config)
+
+	encoded := base64.StdEncoding.EncodeToString([]byte(secretContent))
+	secret, err = secrets.GenSecret(secretName, encoded, OAuthNamespace, secrets.LiteralSecretType)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/transform/oauth/google.go
+++ b/pkg/transform/oauth/google.go
@@ -4,10 +4,10 @@ import (
 	"encoding/base64"
 	"errors"
 
-	"github.com/fusor/cpma/pkg/transform/secrets"
-	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"github.com/fusor/cpma/pkg/config"
+	"github.com/fusor/cpma/pkg/transform/secrets"
 	configv1 "github.com/openshift/api/legacyconfig/v1"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
 //IdentityProviderGoogle is a Google specific identity provider

--- a/pkg/transform/oauth/google_test.go
+++ b/pkg/transform/oauth/google_test.go
@@ -88,6 +88,12 @@ func TestGoogleValidation(t *testing.T) {
 			inputFile:    "testdata/google/invalid-clientsecret-master-config.yaml",
 			expectedErr:  errors.New("Client Secret can't be empty"),
 		},
+		{
+			name:         "fail if key file is present for client secret in google provider",
+			requireError: true,
+			inputFile:    "testdata/google/invalid-keyfile-master-config.yaml",
+			expectedErr:  errors.New("Usage of encrypted files as secret value is not supported"),
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/transform/oauth/google_test.go
+++ b/pkg/transform/oauth/google_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/fusor/cpma/pkg/config"
 	"github.com/fusor/cpma/pkg/transform/oauth"
 	cpmatest "github.com/fusor/cpma/pkg/utils/test"
 	"github.com/stretchr/testify/assert"
@@ -11,6 +12,7 @@ import (
 )
 
 func TestTransformMasterConfigGoogle(t *testing.T) {
+	config := config.LoadConfig()
 	identityProviders, err := cpmatest.LoadIPTestData("testdata/google/test-master-config.yaml")
 	require.NoError(t, err)
 
@@ -43,7 +45,7 @@ func TestTransformMasterConfigGoogle(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resCrd, _, _, err := oauth.Translate(identityProviders)
+			resCrd, _, _, err := oauth.Translate(identityProviders, &config)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedCrd, resCrd)
 		})

--- a/pkg/transform/oauth/htpasswd.go
+++ b/pkg/transform/oauth/htpasswd.go
@@ -5,9 +5,8 @@ import (
 	"errors"
 
 	"github.com/fusor/cpma/pkg/transform/secrets"
-	"k8s.io/apimachinery/pkg/runtime/serializer/json"
-
 	configv1 "github.com/openshift/api/legacyconfig/v1"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
 // IdentityProviderHTPasswd is a htpasswd specific identity provider

--- a/pkg/transform/oauth/htpasswd_test.go
+++ b/pkg/transform/oauth/htpasswd_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/fusor/cpma/pkg/config"
 	"github.com/fusor/cpma/pkg/transform/oauth"
 	cpmatest "github.com/fusor/cpma/pkg/utils/test"
 	"github.com/stretchr/testify/assert"
@@ -11,6 +12,7 @@ import (
 )
 
 func TestTransformMasterConfigHtpasswd(t *testing.T) {
+	config := config.LoadConfig()
 	identityProviders, err := cpmatest.LoadIPTestData("testdata/htpasswd/test-master-config.yaml")
 	require.NoError(t, err)
 
@@ -41,7 +43,7 @@ func TestTransformMasterConfigHtpasswd(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resCrd, _, _, err := oauth.Translate(identityProviders)
+			resCrd, _, _, err := oauth.Translate(identityProviders, &config)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedCrd, resCrd)
 		})

--- a/pkg/transform/oauth/keystone.go
+++ b/pkg/transform/oauth/keystone.go
@@ -6,10 +6,9 @@ import (
 
 	"github.com/fusor/cpma/pkg/transform/configmaps"
 	"github.com/fusor/cpma/pkg/transform/secrets"
+	configv1 "github.com/openshift/api/legacyconfig/v1"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
-
-	configv1 "github.com/openshift/api/legacyconfig/v1"
 )
 
 // IdentityProviderKeystone is a Keystone specific identity provider

--- a/pkg/transform/oauth/keystone_test.go
+++ b/pkg/transform/oauth/keystone_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/fusor/cpma/pkg/config"
 	"github.com/fusor/cpma/pkg/transform/oauth"
 	cpmatest "github.com/fusor/cpma/pkg/utils/test"
 	"github.com/stretchr/testify/assert"
@@ -11,6 +12,7 @@ import (
 )
 
 func TestTransformMasterConfigKeystone(t *testing.T) {
+	config := config.LoadConfig()
 	identityProviders, err := cpmatest.LoadIPTestData("testdata/keystone/test-master-config.yaml")
 	require.NoError(t, err)
 
@@ -46,7 +48,7 @@ func TestTransformMasterConfigKeystone(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resCrd, _, _, err := oauth.Translate(identityProviders)
+			resCrd, _, _, err := oauth.Translate(identityProviders, &config)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedCrd, resCrd)
 		})

--- a/pkg/transform/oauth/ldap.go
+++ b/pkg/transform/oauth/ldap.go
@@ -112,5 +112,9 @@ func validateLDAPProvider(serializer *json.Serializer, p IdentityProvider) error
 		return errors.New("URL can't be empty")
 	}
 
+	if ldap.BindPassword.KeyFile != "" {
+		return errors.New("Usage of encrypted files as bind password value is not supported")
+	}
+
 	return nil
 }

--- a/pkg/transform/oauth/ldap.go
+++ b/pkg/transform/oauth/ldap.go
@@ -1,13 +1,12 @@
 package oauth
 
 import (
-	"github.com/fusor/cpma/pkg/config"
 	"errors"
 
+	"github.com/fusor/cpma/pkg/config"
 	"github.com/fusor/cpma/pkg/transform/configmaps"
-	"k8s.io/apimachinery/pkg/runtime/serializer/json"
-
 	configv1 "github.com/openshift/api/legacyconfig/v1"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
 // IdentityProviderLDAP is a LDAP specific identity provider
@@ -57,12 +56,12 @@ func buildLdapIP(serializer *json.Serializer, p IdentityProvider, config *config
 	idP.LDAP.Attributes.PreferredUsername = ldap.Attributes.PreferredUsername
 	idP.LDAP.BindDN = ldap.BindDN
 
-	if ldap.BindPassword.Value     != "" ||  ldap.BindPassword.File != "" || ldap.BindPassword.Env != "" {
+	if ldap.BindPassword.Value != "" || ldap.BindPassword.File != "" || ldap.BindPassword.Env != "" {
 		bindPassword, err := fetchStringSource(ldap.BindPassword, config)
 		if err != nil {
 			return nil, nil, err
 		}
-	
+
 		idP.LDAP.BindPassword = bindPassword
 	}
 

--- a/pkg/transform/oauth/ldap_test.go
+++ b/pkg/transform/oauth/ldap_test.go
@@ -4,14 +4,15 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
+	"github.com/fusor/cpma/pkg/config"
 	"github.com/fusor/cpma/pkg/transform/oauth"
 	cpmatest "github.com/fusor/cpma/pkg/utils/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTransformMasterConfigLDAP(t *testing.T) {
+	config := config.LoadConfig()
 	identityProviders, err := cpmatest.LoadIPTestData("testdata/ldap/test-master-config.yaml")
 	require.NoError(t, err)
 
@@ -51,7 +52,7 @@ func TestTransformMasterConfigLDAP(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resCrd, _, _, err := oauth.Translate(identityProviders)
+			resCrd, _, _, err := oauth.Translate(identityProviders, &config)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedCrd, resCrd)
 		})

--- a/pkg/transform/oauth/ldap_test.go
+++ b/pkg/transform/oauth/ldap_test.go
@@ -113,6 +113,12 @@ func TestLDAPValidation(t *testing.T) {
 			inputFile:    "testdata/ldap/invalid-url-master-config.yaml",
 			expectedErr:  errors.New("URL can't be empty"),
 		},
+		{
+			name:         "fail if key file is present for bind password in ldap provider",
+			requireError: true,
+			inputFile:    "testdata/ldap/invalid-bpass-master-config.yaml",
+			expectedErr:  errors.New("Usage of encrypted files as bind password value is not supported"),
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/transform/oauth/oauth.go
+++ b/pkg/transform/oauth/oauth.go
@@ -115,19 +115,19 @@ func Translate(identityProviders []IdentityProvider, config *config.Config) (*CR
 
 		switch kind {
 		case "GitHubIdentityProvider":
-			idP, secret, caConfigMap, err = buildGitHubIP(serializer, p)
+			idP, secret, caConfigMap, err = buildGitHubIP(serializer, p, config)
 		case "GitLabIdentityProvider":
 			idP, secret, caConfigMap, err = buildGitLabIP(serializer, p, config)
 		case "GoogleIdentityProvider":
-			idP, secret, err = buildGoogleIP(serializer, p)
+			idP, secret, err = buildGoogleIP(serializer, p, config)
 		case "HTPasswdPasswordIdentityProvider":
 			idP, secret, err = buildHTPasswdIP(serializer, p)
 		case "OpenIDIdentityProvider":
-			idP, secret, err = buildOpenIDIP(serializer, p)
+			idP, secret, err = buildOpenIDIP(serializer, p, config)
 		case "RequestHeaderIdentityProvider":
 			idP, caConfigMap, err = buildRequestHeaderIP(serializer, p)
 		case "LDAPPasswordIdentityProvider":
-			idP, caConfigMap, err = buildLdapIP(serializer, p)
+			idP, caConfigMap, err = buildLdapIP(serializer, p, config)
 		case "KeystonePasswordIdentityProvider":
 			idP, certSecret, keySecret, caConfigMap, err = buildKeystoneIP(serializer, p)
 		case "BasicAuthPasswordIdentityProvider":
@@ -230,28 +230,28 @@ func validateClientData(clientID string, clientSecret configv1.StringSource) err
 	return nil
 }
 
-func fetchSecret(secret configv1.StringSource, config *config.Config) (string, error) {
-	if secret.Value != "" {
-		return secret.Value, nil
+func fetchStringSource(stringSource configv1.StringSource, config *config.Config) (string, error) {
+	if stringSource.Value != "" {
+		return stringSource.Value, nil
 	}
 
-	if secret.File != "" {
-		secretFileContent, err := config.Fetch(secret.File)
+	if stringSource.File != "" {
+		fileContent, err := config.Fetch(stringSource.File)
 		if err != nil {
 			return "", nil
 		}
 
-		secretFileString := strings.TrimSuffix(string(secretFileContent), "\n")
-		return secretFileString, nil
+		fileString := strings.TrimSuffix(string(fileContent), "\n")
+		return fileString, nil
 	}
 
-	if secret.Env != "" {
-		secretEnv, err := config.Env(secret.Env)
+	if stringSource.Env != "" {
+		env, err := config.FetchEnv(stringSource.Env)
 		if err != nil {
 			return "", nil
 		}
 
-		return secretEnv, nil
+		return env, nil
 	}
 
 	return "", nil

--- a/pkg/transform/oauth/oauth.go
+++ b/pkg/transform/oauth/oauth.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/fusor/cpma/pkg/config"
+	"github.com/fusor/cpma/pkg/io"
 	"github.com/fusor/cpma/pkg/transform/configmaps"
 	"github.com/fusor/cpma/pkg/transform/secrets"
 	configv1 "github.com/openshift/api/legacyconfig/v1"
@@ -245,7 +246,7 @@ func fetchStringSource(stringSource configv1.StringSource, config *config.Config
 	}
 
 	if stringSource.Env != "" {
-		env, err := config.FetchEnv(stringSource.Env)
+		env, err := io.FetchEnv(config.Hostname, stringSource.Env)
 		if err != nil {
 			return "", nil
 		}

--- a/pkg/transform/oauth/oauth.go
+++ b/pkg/transform/oauth/oauth.go
@@ -7,14 +7,13 @@ import (
 	"github.com/fusor/cpma/pkg/config"
 	"github.com/fusor/cpma/pkg/transform/configmaps"
 	"github.com/fusor/cpma/pkg/transform/secrets"
+	configv1 "github.com/openshift/api/legacyconfig/v1"
+	oauthv1 "github.com/openshift/api/oauth/v1"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/client-go/kubernetes/scheme"
-
-	configv1 "github.com/openshift/api/legacyconfig/v1"
-	oauthv1 "github.com/openshift/api/oauth/v1"
 )
 
 func init() {

--- a/pkg/transform/oauth/oauth_test.go
+++ b/pkg/transform/oauth/oauth_test.go
@@ -5,16 +5,17 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/fusor/cpma/pkg/config"
 	"github.com/fusor/cpma/pkg/transform/oauth"
+	configv1 "github.com/openshift/api/legacyconfig/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/client-go/kubernetes/scheme"
-
-	configv1 "github.com/openshift/api/legacyconfig/v1"
 	k8sjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/client-go/kubernetes/scheme"
 )
 
 func TestTransformMasterConfig(t *testing.T) {
+	config := config.LoadConfig()
 	file := "testdata/bulk-test-master-config.yaml"
 
 	content, err := ioutil.ReadFile(file)
@@ -59,7 +60,7 @@ func TestTransformMasterConfig(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resCrd, _, _, err := oauth.Translate(identityProviders)
+			resCrd, _, _, err := oauth.Translate(identityProviders, &config)
 			require.NoError(t, err)
 			assert.Equal(t, len(resCrd.Spec.IdentityProviders), 9)
 			assert.Equal(t, resCrd.Spec.IdentityProviders[0].(*oauth.IdentityProviderBasicAuth).Type, "BasicAuth")
@@ -77,6 +78,7 @@ func TestTransformMasterConfig(t *testing.T) {
 }
 
 func TestGenYAML(t *testing.T) {
+	config := config.LoadConfig()
 	testCases := []struct {
 		name                    string
 		inputConfigfile         string
@@ -136,7 +138,7 @@ func TestGenYAML(t *testing.T) {
 					})
 			}
 
-			crd, secrets, configMaps, err := oauth.Translate(identityProviders)
+			crd, secrets, configMaps, err := oauth.Translate(identityProviders, &config)
 			require.NoError(t, err)
 
 			CRD, err := crd.GenYAML()

--- a/pkg/transform/oauth/openid.go
+++ b/pkg/transform/oauth/openid.go
@@ -1,6 +1,8 @@
 package oauth
 
 import (
+	"github.com/fusor/cpma/pkg/config"
+	"encoding/base64"
 	"errors"
 
 	"github.com/fusor/cpma/pkg/transform/secrets"
@@ -36,7 +38,7 @@ type OpenIDURLs struct {
 	Token     string `yaml:"token"`
 }
 
-func buildOpenIDIP(serializer *json.Serializer, p IdentityProvider) (*IdentityProviderOpenID, *secrets.Secret, error) {
+func buildOpenIDIP(serializer *json.Serializer, p IdentityProvider, config *config.Config) (*IdentityProviderOpenID, *secrets.Secret, error) {
 	var (
 		err    error
 		secret *secrets.Secret
@@ -62,7 +64,10 @@ func buildOpenIDIP(serializer *json.Serializer, p IdentityProvider) (*IdentityPr
 
 	secretName := p.Name + "-secret"
 	idP.OpenID.ClientSecret.Name = secretName
-	secret, err = secrets.GenSecret(secretName, openID.ClientSecret.Value, OAuthNamespace, secrets.LiteralSecretType)
+	secretContent, err := fetchStringSource(openID.ClientSecret, config)
+
+	encoded := base64.StdEncoding.EncodeToString([]byte(secretContent))
+	secret, err = secrets.GenSecret(secretName, encoded, OAuthNamespace, secrets.LiteralSecretType)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/transform/oauth/openid.go
+++ b/pkg/transform/oauth/openid.go
@@ -1,14 +1,13 @@
 package oauth
 
 import (
-	"github.com/fusor/cpma/pkg/config"
 	"encoding/base64"
 	"errors"
 
+	"github.com/fusor/cpma/pkg/config"
 	"github.com/fusor/cpma/pkg/transform/secrets"
-	"k8s.io/apimachinery/pkg/runtime/serializer/json"
-
 	configv1 "github.com/openshift/api/legacyconfig/v1"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
 // IdentityProviderOpenID is an Open ID specific identity provider

--- a/pkg/transform/oauth/openid.go
+++ b/pkg/transform/oauth/openid.go
@@ -90,6 +90,10 @@ func validateOpenIDProvider(serializer *json.Serializer, p IdentityProvider) err
 		return err
 	}
 
+	if openID.ClientSecret.KeyFile != "" {
+		return errors.New("Usage of encrypted files as secret value is not supported")
+	}
+
 	if err := validateClientData(openID.ClientID, openID.ClientSecret); err != nil {
 		return err
 	}

--- a/pkg/transform/oauth/openid_test.go
+++ b/pkg/transform/oauth/openid_test.go
@@ -111,6 +111,12 @@ func TestOpenIDValidation(t *testing.T) {
 			inputFile:    "testdata/openid/invalid-token-master-config.yaml",
 			expectedErr:  errors.New("Token endpoint can't be empty"),
 		},
+		{
+			name:         "fail if key file is present for client secret in openid provider",
+			requireError: true,
+			inputFile:    "testdata/openid/invalid-keyfile-master-config.yaml",
+			expectedErr:  errors.New("Usage of encrypted files as secret value is not supported"),
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/transform/oauth/openid_test.go
+++ b/pkg/transform/oauth/openid_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/fusor/cpma/pkg/config"
 	"github.com/fusor/cpma/pkg/transform/oauth"
 	cpmatest "github.com/fusor/cpma/pkg/utils/test"
 	"github.com/stretchr/testify/assert"
@@ -11,6 +12,7 @@ import (
 )
 
 func TestTransformMasterConfigOpenID(t *testing.T) {
+	config := config.LoadConfig()
 	identityProviders, err := cpmatest.LoadIPTestData("testdata/openid/test-master-config.yaml")
 	require.NoError(t, err)
 
@@ -48,7 +50,7 @@ func TestTransformMasterConfigOpenID(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resCrd, _, _, err := oauth.Translate(identityProviders)
+			resCrd, _, _, err := oauth.Translate(identityProviders, &config)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedCrd, resCrd)
 		})

--- a/pkg/transform/oauth/requestheader.go
+++ b/pkg/transform/oauth/requestheader.go
@@ -3,10 +3,9 @@ package oauth
 import (
 	"errors"
 
-	"k8s.io/apimachinery/pkg/runtime/serializer/json"
-
 	"github.com/fusor/cpma/pkg/transform/configmaps"
 	configv1 "github.com/openshift/api/legacyconfig/v1"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
 // IdentityProviderRequestHeader is a request header specific identity provider

--- a/pkg/transform/oauth/requestheader_test.go
+++ b/pkg/transform/oauth/requestheader_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/fusor/cpma/pkg/config"
 	"github.com/fusor/cpma/pkg/transform/oauth"
 	cpmatest "github.com/fusor/cpma/pkg/utils/test"
 	"github.com/stretchr/testify/assert"
@@ -11,6 +12,7 @@ import (
 )
 
 func TestTransformMasterConfigRequestHeader(t *testing.T) {
+	config := config.LoadConfig()
 	identityProviders, err := cpmatest.LoadIPTestData("testdata/requestheader/test-master-config.yaml")
 	require.NoError(t, err)
 
@@ -49,7 +51,7 @@ func TestTransformMasterConfigRequestHeader(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resCrd, _, _, err := oauth.Translate(identityProviders)
+			resCrd, _, _, err := oauth.Translate(identityProviders, &config)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedCrd, resCrd)
 		})

--- a/pkg/transform/oauth/testdata/github/invalid-keyfile-master-config.yaml
+++ b/pkg/transform/oauth/testdata/github/invalid-keyfile-master-config.yaml
@@ -1,0 +1,34 @@
+oauthConfig:
+  assetPublicURL: https://openshift.gildub2.lab.pnq2.cee.redhat.com/console/
+  grantConfig:
+    method: auto
+  identityProviders:
+  - name: github123456789
+    challenge: false
+    login: true
+    mappingMethod: claim
+    provider:
+      apiVersion: v1
+      kind: GitHubIdentityProvider
+      ca: github.crt
+      clientID: 2d85ea3f45d6777bffd7
+      clientSecret:
+        file: test.txt
+        keyfile: file.txt
+      hostname: test.example.com
+      organizations:
+      - myorganization1
+      - myorganization2
+      teams:
+      - myorganization1/team-a
+      - myorganization2/team-b
+  masterCA: ca-bundle.crt
+  masterPublicURL: https://openshift.gildub2.lab.pnq2.cee.redhat.com:443
+  masterURL: https://openshift.internal.gildub2.lab.pnq2.cee.redhat.com:443
+  sessionConfig:
+    sessionMaxAgeSeconds: 3600
+    sessionName: ssn
+    sessionSecretsFile: /etc/origin/master/session-secrets.yaml
+  tokenConfig:
+    accessTokenMaxAgeSeconds: 86400
+    authorizeTokenMaxAgeSeconds: 500

--- a/pkg/transform/oauth/testdata/gitlab/invalid-keyfile-master-config.yaml
+++ b/pkg/transform/oauth/testdata/gitlab/invalid-keyfile-master-config.yaml
@@ -1,0 +1,29 @@
+oauthConfig:
+  assetPublicURL: https://openshift.gildub2.lab.pnq2.cee.redhat.com/console/
+  grantConfig:
+    method: auto
+  identityProviders:
+  - name: gitlab123456789
+    challenge: true
+    login: true
+    mappingMethod: claim
+    provider:
+      apiVersion: v1
+      kind: GitLabIdentityProvider
+      ca: gitlab.crt
+      legacy: true
+      url: https://gitlab.com/
+      clientID: fake-id
+      clientSecret:
+        file: test.txt
+        keyfile: file.txt
+  masterCA: ca-bundle.crt
+  masterPublicURL: https://openshift.gildub2.lab.pnq2.cee.redhat.com:443
+  masterURL: https://openshift.internal.gildub2.lab.pnq2.cee.redhat.com:443
+  sessionConfig:
+    sessionMaxAgeSeconds: 3600
+    sessionName: ssn
+    sessionSecretsFile: /etc/origin/master/session-secrets.yaml
+  tokenConfig:
+    accessTokenMaxAgeSeconds: 86400
+    authorizeTokenMaxAgeSeconds: 500

--- a/pkg/transform/oauth/testdata/google/invalid-keyfile-master-config.yaml
+++ b/pkg/transform/oauth/testdata/google/invalid-keyfile-master-config.yaml
@@ -1,0 +1,27 @@
+oauthConfig:
+  assetPublicURL: https://openshift.gildub2.lab.pnq2.cee.redhat.com/console/
+  grantConfig:
+    method: auto
+  identityProviders:
+  - name: google123456789123456789
+    challenge: false
+    login: true
+    mappingMethod: claim
+    provider:
+      apiVersion: v1
+      kind: GoogleIdentityProvider
+      clientID: fake
+      clientSecret:
+        file: test.txt
+        keyfile: file.txt
+      hostedDomain: test.example.com
+  masterCA: ca-bundle.crt
+  masterPublicURL: https://openshift.gildub2.lab.pnq2.cee.redhat.com:443
+  masterURL: https://openshift.internal.gildub2.lab.pnq2.cee.redhat.com:443
+  sessionConfig:
+    sessionMaxAgeSeconds: 3600
+    sessionName: ssn
+    sessionSecretsFile: /etc/origin/master/session-secrets.yaml
+  tokenConfig:
+    accessTokenMaxAgeSeconds: 86400
+    authorizeTokenMaxAgeSeconds: 500

--- a/pkg/transform/oauth/testdata/ldap/invalid-bpass-master-config.yaml
+++ b/pkg/transform/oauth/testdata/ldap/invalid-bpass-master-config.yaml
@@ -1,0 +1,38 @@
+oauthConfig:
+  assetPublicURL: https://openshift.gildub2.lab.pnq2.cee.redhat.com/console/
+  grantConfig:
+    method: auto
+  identityProviders:
+  - name: "my_ldap_provider" 
+    challenge: true 
+    login: true 
+    mappingMethod: claim 
+    provider:
+      apiVersion: v1
+      kind: LDAPPasswordIdentityProvider
+      attributes:
+        id: 
+        - dn
+        email: 
+        - mail
+        name: 
+        - cn
+        preferredUsername: 
+        - uid
+      bindDN: "123" 
+      bindPassword:
+        file: test.txt
+        keyfile: file.txt 
+      ca: my-ldap-ca-bundle.crt 
+      insecure: false 
+      url: "ldap://ldap.example.com/ou=users,dc=acme,dc=com?uid"
+  masterCA: ca-bundle.crt
+  masterPublicURL: https://openshift.gildub2.lab.pnq2.cee.redhat.com:443
+  masterURL: https://openshift.internal.gildub2.lab.pnq2.cee.redhat.com:443
+  sessionConfig:
+    sessionMaxAgeSeconds: 3600
+    sessionName: ssn
+    sessionSecretsFile: /etc/origin/master/session-secrets.yaml
+  tokenConfig:
+    accessTokenMaxAgeSeconds: 86400
+    authorizeTokenMaxAgeSeconds: 500

--- a/pkg/transform/oauth/testdata/openid/invalid-keyfile-master-config.yaml
+++ b/pkg/transform/oauth/testdata/openid/invalid-keyfile-master-config.yaml
@@ -1,0 +1,50 @@
+oauthConfig:
+  assetPublicURL: https://openshift.gildub2.lab.pnq2.cee.redhat.com/console/
+  grantConfig:
+    method: auto
+  identityProviders:
+  - name: my_openid_connect
+    challenge: false
+    login: true
+    mappingMethod: claim
+    provider:
+      apiVersion: v1
+      kind: OpenIDIdentityProvider
+      clientID: testid
+      clientSecret:
+        file: test.txt
+        keyfile: file.txt
+      ca: my-openid-ca-bundle.crt 
+      extraScopes: 
+      - email
+      - profile
+      extraAuthorizeParameters: 
+        include_granted_scopes: "true"
+      claims:
+        id: 
+        - custom_id_claim
+        - sub
+        preferredUsername: 
+        - preferred_username
+        - email
+        name: 
+        - nickname
+        - given_name
+        - name
+        email: 
+        - custom_email_claim
+        - email
+      urls:
+        authorize: https://myidp.example.com/oauth2/authorize
+        token: https://myidp.example.com/oauth2/token
+        userInfo: https://myidp.example.com/oauth2/userinfo
+  masterCA: ca-bundle.crt
+  masterPublicURL: https://openshift.gildub2.lab.pnq2.cee.redhat.com:443
+  masterURL: https://openshift.internal.gildub2.lab.pnq2.cee.redhat.com:443
+  sessionConfig:
+    sessionMaxAgeSeconds: 3600
+    sessionName: ssn
+    sessionSecretsFile: /etc/origin/master/session-secrets.yaml
+  tokenConfig:
+    accessTokenMaxAgeSeconds: 86400
+    authorizeTokenMaxAgeSeconds: 500

--- a/pkg/transform/oauth_transform.go
+++ b/pkg/transform/oauth_transform.go
@@ -14,6 +14,7 @@ import (
 // OAuthExtraction holds OAuth data extracted from OCP3
 type OAuthExtraction struct {
 	IdentityProviders []oauth.IdentityProvider
+	Config            *config.Config
 }
 
 // OAuthTransform is an OAuth specific transform
@@ -27,7 +28,7 @@ func (e OAuthExtraction) Transform() (Output, error) {
 
 	var ocp4Cluster Cluster
 
-	oauth, secrets, configMaps, err := oauth.Translate(e.IdentityProviders)
+	oauth, secrets, configMaps, err := oauth.Translate(e.IdentityProviders, e.Config)
 	if err != nil {
 		return nil, errors.New("Unable to generate OAuth CRD")
 	}
@@ -86,6 +87,8 @@ func (e OAuthTransform) Extract() (Extraction, error) {
 	}
 
 	var extraction OAuthExtraction
+	extraction.Config = e.Config
+
 	var htContent, caContent, crtContent, keyContent []byte
 
 	if masterConfig.OAuthConfig != nil {

--- a/pkg/transform/oauth_transform_test.go
+++ b/pkg/transform/oauth_transform_test.go
@@ -76,7 +76,7 @@ func TestOAuthExtractionTransform(t *testing.T) {
 	githubSecretCrd.Type = "Opaque"
 	githubSecretCrd.Metadata.Namespace = oauth.OAuthNamespace
 	githubSecretCrd.Metadata.Name = "github123456789-secret"
-	githubSecretCrd.Data = secrets.LiteralSecret{ClientSecret: base64.StdEncoding.EncodeToString([]byte("e16a59ad33d7c29fd4354f46059f0950c609a7ea"))}
+	githubSecretCrd.Data = secrets.LiteralSecret{ClientSecret: base64.StdEncoding.EncodeToString([]byte("fake-secret"))}
 
 	var githubConfigMap configmaps.ConfigMap
 	githubConfigMap.APIVersion = "v1"
@@ -102,7 +102,7 @@ func TestOAuthExtractionTransform(t *testing.T) {
 	gitlabSecretCrd.Type = "Opaque"
 	gitlabSecretCrd.Metadata.Namespace = oauth.OAuthNamespace
 	gitlabSecretCrd.Metadata.Name = "gitlab123456789-secret"
-	gitlabSecretCrd.Data = secrets.LiteralSecret{ClientSecret: "fake-secret"}
+	gitlabSecretCrd.Data = secrets.LiteralSecret{ClientSecret: base64.StdEncoding.EncodeToString([]byte("fake-secret"))}
 
 	var gitlabConfigMap configmaps.ConfigMap
 	gitlabConfigMap.APIVersion = "v1"
@@ -127,7 +127,7 @@ func TestOAuthExtractionTransform(t *testing.T) {
 	googleSecretCrd.Type = "Opaque"
 	googleSecretCrd.Metadata.Namespace = oauth.OAuthNamespace
 	googleSecretCrd.Metadata.Name = "google123456789123456789-secret"
-	googleSecretCrd.Data = secrets.LiteralSecret{ClientSecret: "e16a59ad33d7c29fd4354f46059f0950c609a7ea"}
+	googleSecretCrd.Data = secrets.LiteralSecret{ClientSecret: base64.StdEncoding.EncodeToString([]byte("fake-secret"))}
 
 	var keystoneIDP oauth.IdentityProviderKeystone
 	keystoneIDP.Type = "Keystone"
@@ -245,7 +245,7 @@ func TestOAuthExtractionTransform(t *testing.T) {
 	openidSecretCrd.Type = "Opaque"
 	openidSecretCrd.Metadata.Namespace = oauth.OAuthNamespace
 	openidSecretCrd.Metadata.Name = "my_openid_connect-secret"
-	openidSecretCrd.Data = secrets.LiteralSecret{ClientSecret: "testsecret"}
+	openidSecretCrd.Data = secrets.LiteralSecret{ClientSecret: base64.StdEncoding.EncodeToString([]byte("testsecret"))}
 
 	expectedCrd.Spec.IdentityProviders = append(expectedCrd.Spec.IdentityProviders, basicAuthIDP)
 	expectedCrd.Spec.IdentityProviders = append(expectedCrd.Spec.IdentityProviders, githubIDP)

--- a/pkg/transform/testdata/bulk-test-master-config.yaml
+++ b/pkg/transform/testdata/bulk-test-master-config.yaml
@@ -23,7 +23,7 @@ oauthConfig:
       kind: GitHubIdentityProvider
       ca: github.crt
       clientID: 2d85ea3f45d6777bffd7
-      clientSecret: e16a59ad33d7c29fd4354f46059f0950c609a7ea
+      clientSecret: fake-secret
       hostname: test.example.com
       organizations:
       - myorganization1
@@ -51,7 +51,7 @@ oauthConfig:
       apiVersion: v1
       kind: GoogleIdentityProvider
       clientID: 82342890327-tf5lqn4eikdf4cb4edfm85jiqotvurpq.apps.googleusercontent.com
-      clientSecret: e16a59ad33d7c29fd4354f46059f0950c609a7ea
+      clientSecret: fake-secret
       hostedDomain: test.example.com
   - name: htpasswd_auth
     login: true


### PR DESCRIPTION
This PR should fix issue decribed here: 

> BindPassword attribute for LDAP can be a clear text value, env var or a file reference. You can see the definition below.
https://github.com/openshift/api/blob/a2de4d01c8717dc2c9fc6429080b26e9d8bb2373/osin/v1/types.go#L156
> https://github.com/openshift/api/blob/6820a28f1dcf8f036f94a56164dfaeb842e6b28a/config/v1/types.go#L119
> Right now we only handle BindPassword if it was defined as a clear text value and skipping cases when it's something else https://github.com/fusor/cpma/blob/master/pkg/transform/oauth/ldap.go#L56 . Same problem for GitHub, GitLab, Google, OpenID.
> https://docs.openshift.com/container-platform/3.11/install_config/configuring_authentication.html#LDAPPasswordIdentityProvider
> https://docs.openshift.com/container-platform/3.11/install_config/configuring_authentication.html#GitHub
