### PR TITLE
IO: Fix path after remote file fetch

### DIFF
--- a/pkg/io/io.go
+++ b/pkg/io/io.go
@@ -21,7 +21,7 @@ var FetchFile = func(src string) ([]byte, error) {
 	if err != nil {
 		host := env.Config().GetString("Source")
 		remotehost.Fetch(host, src, dst)
-		netFile, err := ioutil.ReadFile(src)
+		netFile, err := ioutil.ReadFile(dst)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Fix wrong path introduced by https://github.com/fusor/cpma/pull/184