### PR TITLE
Get config values from CLI arguments

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,11 +25,24 @@ import (
 
 func init() {
 	cobra.OnInitialize()
+
+	// Get config file from CLI argument an save it to viper config
 	rootCmd.PersistentFlags().StringVar(&env.ConfigFile, "config", "", "config file (Default searches ./cpma.yaml, $HOME/cpma.yml)")
 
+	// Set log level from CLI argument
 	rootCmd.PersistentFlags().Bool("debug", false, "show debug ouput")
 	env.Config().BindPFlag("Debug", rootCmd.PersistentFlags().Lookup("debug"))
 
+	// Get OCP3 source cluster and save it to viper config
+	rootCmd.PersistentFlags().StringP("source", "s", "", "OCP3 cluster hostname")
+	env.Config().BindPFlag("Source", rootCmd.PersistentFlags().Lookup("source"))
+
+	// Get ssh config values from CLI argument
+	rootCmd.PersistentFlags().StringVarP(&env.Login, "login", "l", "", "OCP3 ssh login")
+	rootCmd.PersistentFlags().StringVarP(&env.PrivateKey, "key", "k", "", "OCP3 ssh key path")
+	rootCmd.PersistentFlags().StringVarP(&env.Port, "port", "p", "", "OCP3 ssh port")
+
+	// Get config file from CLI argument an save to viper config
 	rootCmd.PersistentFlags().StringP("output-dir", "o", path.Dir(""), "set the directory to store extracted configuration.")
 	env.Config().BindPFlag("OutputDir", rootCmd.PersistentFlags().Lookup("output-dir"))
 }

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -90,6 +90,7 @@ func promptMissingValues() {
 		login := ""
 		prompt := &survey.Input{
 			Message: "SSH login",
+			Default: "root",
 		}
 		survey.AskOne(prompt, &login, nil)
 		sshCreds["login"] = login
@@ -108,6 +109,7 @@ func promptMissingValues() {
 		port := ""
 		prompt := &survey.Input{
 			Message: "SSH Port",
+			Default: "22",
 		}
 		survey.AskOne(prompt, &port, nil)
 		sshCreds["port"] = port

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -21,6 +21,12 @@ const (
 var (
 	// ConfigFile - keeps full path to the configuration file
 	ConfigFile string
+	// Login ssh login
+	Login string
+	// PrivateKey private key path
+	PrivateKey string
+	// Port ssh port
+	Port string
 
 	viperConfig *viper.Viper
 )
@@ -61,6 +67,8 @@ func InitConfig() error {
 	if err := viperConfig.ReadInConfig(); err != nil {
 		logrus.Debug("Can't read config file, all values will be prompted, err: ", err)
 	}
+
+	getNestedArgValues()
 
 	promptMissingValues()
 
@@ -115,6 +123,22 @@ func promptMissingValues() {
 		viperConfig.Set("OutputDir", outPutDir)
 	}
 
+	viperConfig.Set("SSHCreds", sshCreds)
+}
+
+func getNestedArgValues() {
+	sshCreds := Config().GetStringMapString("SSHCreds")
+	if Login != "" {
+		sshCreds["login"] = Login
+	}
+
+	if PrivateKey != "" {
+		sshCreds["privatekey"] = PrivateKey
+	}
+
+	if Port != "" {
+		sshCreds["port"] = Port
+	}
 	viperConfig.Set("SSHCreds", sshCreds)
 }
 


### PR DESCRIPTION
This PR introduces ability to get config values from CLI arguments,  as an alternative to prompting and yaml file.
`./bin/cpma --source master-0.ademicev3112.lab.rdu2.cee.redhat.com --login root --key /Users/ademicev/.ssh/quicklab.key --port 22 -o ./data`