### PR TITLE
Fix debug mode message

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -204,7 +204,6 @@ func InitLogger() {
 		TimestampFormat: time.RFC822,
 	})
 	logrus.SetLevel(logLevel)
-	logrus.Debugf("%s is running in debug mode", AppName)
 
 	fileHook, _ := NewLogFileHook(
 		LogFileConfig{
@@ -217,4 +216,6 @@ func InitLogger() {
 		},
 	)
 	logrus.AddHook(fileHook)
+
+	logrus.Debugf("%s is running in debug mode", AppName)
 }


### PR DESCRIPTION
This was being printed before the file logger was set up so the message does not appear as expected.