### PR TITLE
Use logrus hooks to handle log output

### DIFF
--- a/pkg/env/loghooks.go
+++ b/pkg/env/loghooks.go
@@ -21,6 +21,13 @@ type LogFileHook struct {
 	logWriter io.Writer
 }
 
+// ConsoleWriterHook is a hook that writes logs of specified LogLevels to specified Writer
+type ConsoleWriterHook struct {
+	Writer    io.Writer
+	LogLevels []logrus.Level
+	Formatter logrus.Formatter
+}
+
 // NewLogFileHook instantiates hook and implements Hook interface
 func NewLogFileHook(config LogFileConfig) (logrus.Hook, error) {
 	hook := LogFileHook{
@@ -45,7 +52,32 @@ func (hook *LogFileHook) Fire(entry *logrus.Entry) (err error) {
 	if err != nil {
 		return err
 	}
-	hook.logWriter.Write(b)
+
+	_, err = hook.logWriter.Write(b)
+	if err != nil {
+		return err
+	}
 
 	return nil
+}
+
+// Fire will be called when some logging function is called with current hook
+// It will format log entry to string and write it to appropriate writer
+func (hook *ConsoleWriterHook) Fire(entry *logrus.Entry) error {
+	b, err := hook.Formatter.Format(entry)
+	if err != nil {
+		return err
+	}
+
+	_, err = hook.Writer.Write(b)
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
+// Levels define on which log levels this hook would trigger
+func (hook *ConsoleWriterHook) Levels() []logrus.Level {
+	return hook.LogLevels
 }


### PR DESCRIPTION
I introduced usage of logrus hooks to handle log final output:
1. All logs will always be sent to cpma.log.json
2. Error logs will always appear in console, so user can get reason of cpma failure without checking log file.
3. All will appear in terminal if `--console-logs` flag was set 