### PR TITLE
Add ingress config to SDN report

### DIFF
--- a/pkg/transform/sdn_transform.go
+++ b/pkg/transform/sdn_transform.go
@@ -103,6 +103,15 @@ func (e SDNExtraction) buildReportOutput() (Output, error) {
 			})
 	}
 
+	reportOutput.Reports = append(reportOutput.Reports,
+		Report{
+			Name:       e.MasterConfig.NetworkConfig.IngressIPNetworkCIDR,
+			Kind:       "IngressIPNetworkCIDR",
+			Supported:  false,
+			Confidence: "red",
+			Comment:    "Translation of this configuration is not supported, refer to ingress operator configuration for more information",
+		})
+
 	return reportOutput, nil
 }
 


### PR DESCRIPTION
This PR adds ingress config to SDN report.
I don't think we can migrate it, because the definition of CR for configuring cluster-ingress-operator in OCP4, is using `domain`:
```
apiVersion: config.openshift.io/v1
kind: Ingress
metadata:
  name: cluster
spec:
  domain: apps.openshiftdemos.com
```

In OCP3 we are working with `ingressIPNetworkCIDR` in network config
```
networkConfig:
  clusterNetworks:
  - cidr: 10.128.0.0/14 
    hostSubnetLength: 9 
  externalIPNetworkCIDRs: null
  hostSubnetLength: 9
  ingressIPNetworkCIDR: 172.29.0.0/16
  networkPluginName: redhat/openshift-ovs-multitenant 
  serviceNetworkCIDR: 172.30.0.0/16
```
I am not sure if domain can represent a CIDR notation, because notation can include a range of IP addresses, but my knowledge is very limited in this area.

https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing
https://docs.openshift.com/container-platform/3.11/install_config/configuring_sdn.html
https://docs.openshift.com/container-platform/4.1/networking/ingress-operator.html#configuring-ingress

@jmontleon @gildub @arapov What do you think?

Closes https://github.com/fusor/cpma/issues/199