### PR TITLE
Add translate and report for oAuth token config

### DIFF
--- a/pkg/transform/oauth/basicauth_test.go
+++ b/pkg/transform/oauth/basicauth_test.go
@@ -45,7 +45,7 @@ func TestTransformMasterConfigBasicAuth(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			oauthResources, err := oauth.Translate(identityProviders)
+			oauthResources, err := oauth.Translate(identityProviders, oauth.TokenConfig{})
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedCrd, oauthResources.OAuthCRD)
 		})

--- a/pkg/transform/oauth/basicauth_test.go
+++ b/pkg/transform/oauth/basicauth_test.go
@@ -45,9 +45,9 @@ func TestTransformMasterConfigBasicAuth(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resCrd, _, _, err := oauth.Translate(identityProviders)
+			oauthResources, err := oauth.Translate(identityProviders)
 			require.NoError(t, err)
-			assert.Equal(t, tc.expectedCrd, resCrd)
+			assert.Equal(t, tc.expectedCrd, oauthResources.OAuthCRD)
 		})
 	}
 }

--- a/pkg/transform/oauth/github_test.go
+++ b/pkg/transform/oauth/github_test.go
@@ -46,9 +46,9 @@ func TestTransformMasterConfigGithub(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resCrd, _, _, err := oauth.Translate(identityProviders)
+			oauthResources, err := oauth.Translate(identityProviders)
 			require.NoError(t, err)
-			assert.Equal(t, tc.expectedCrd, resCrd)
+			assert.Equal(t, tc.expectedCrd, oauthResources.OAuthCRD)
 		})
 	}
 }

--- a/pkg/transform/oauth/github_test.go
+++ b/pkg/transform/oauth/github_test.go
@@ -46,7 +46,7 @@ func TestTransformMasterConfigGithub(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			oauthResources, err := oauth.Translate(identityProviders)
+			oauthResources, err := oauth.Translate(identityProviders, oauth.TokenConfig{})
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedCrd, oauthResources.OAuthCRD)
 		})

--- a/pkg/transform/oauth/gitlab_test.go
+++ b/pkg/transform/oauth/gitlab_test.go
@@ -44,7 +44,7 @@ func TestTransformMasterConfigGitlab(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			oauthResources, err := oauth.Translate(identityProviders)
+			oauthResources, err := oauth.Translate(identityProviders, oauth.TokenConfig{})
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedCrd, oauthResources.OAuthCRD)
 		})

--- a/pkg/transform/oauth/gitlab_test.go
+++ b/pkg/transform/oauth/gitlab_test.go
@@ -44,9 +44,9 @@ func TestTransformMasterConfigGitlab(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resCrd, _, _, err := oauth.Translate(identityProviders)
+			oauthResources, err := oauth.Translate(identityProviders)
 			require.NoError(t, err)
-			assert.Equal(t, tc.expectedCrd, resCrd)
+			assert.Equal(t, tc.expectedCrd, oauthResources.OAuthCRD)
 		})
 	}
 }

--- a/pkg/transform/oauth/google_test.go
+++ b/pkg/transform/oauth/google_test.go
@@ -43,7 +43,7 @@ func TestTransformMasterConfigGoogle(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			oauthResources, err := oauth.Translate(identityProviders)
+			oauthResources, err := oauth.Translate(identityProviders, oauth.TokenConfig{})
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedCrd, oauthResources.OAuthCRD)
 		})

--- a/pkg/transform/oauth/google_test.go
+++ b/pkg/transform/oauth/google_test.go
@@ -43,9 +43,9 @@ func TestTransformMasterConfigGoogle(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resCrd, _, _, err := oauth.Translate(identityProviders)
+			oauthResources, err := oauth.Translate(identityProviders)
 			require.NoError(t, err)
-			assert.Equal(t, tc.expectedCrd, resCrd)
+			assert.Equal(t, tc.expectedCrd, oauthResources.OAuthCRD)
 		})
 	}
 }

--- a/pkg/transform/oauth/htpasswd_test.go
+++ b/pkg/transform/oauth/htpasswd_test.go
@@ -41,9 +41,9 @@ func TestTransformMasterConfigHtpasswd(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resCrd, _, _, err := oauth.Translate(identityProviders)
+			oauthResources, err := oauth.Translate(identityProviders)
 			require.NoError(t, err)
-			assert.Equal(t, tc.expectedCrd, resCrd)
+			assert.Equal(t, tc.expectedCrd, oauthResources.OAuthCRD)
 		})
 	}
 }

--- a/pkg/transform/oauth/htpasswd_test.go
+++ b/pkg/transform/oauth/htpasswd_test.go
@@ -41,7 +41,7 @@ func TestTransformMasterConfigHtpasswd(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			oauthResources, err := oauth.Translate(identityProviders)
+			oauthResources, err := oauth.Translate(identityProviders, oauth.TokenConfig{})
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedCrd, oauthResources.OAuthCRD)
 		})

--- a/pkg/transform/oauth/keystone_test.go
+++ b/pkg/transform/oauth/keystone_test.go
@@ -46,9 +46,9 @@ func TestTransformMasterConfigKeystone(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resCrd, _, _, err := oauth.Translate(identityProviders)
+			oauthResources, err := oauth.Translate(identityProviders)
 			require.NoError(t, err)
-			assert.Equal(t, tc.expectedCrd, resCrd)
+			assert.Equal(t, tc.expectedCrd, oauthResources.OAuthCRD)
 		})
 	}
 }

--- a/pkg/transform/oauth/keystone_test.go
+++ b/pkg/transform/oauth/keystone_test.go
@@ -46,7 +46,7 @@ func TestTransformMasterConfigKeystone(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			oauthResources, err := oauth.Translate(identityProviders)
+			oauthResources, err := oauth.Translate(identityProviders, oauth.TokenConfig{})
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedCrd, oauthResources.OAuthCRD)
 		})

--- a/pkg/transform/oauth/ldap_test.go
+++ b/pkg/transform/oauth/ldap_test.go
@@ -50,7 +50,7 @@ func TestTransformMasterConfigLDAP(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			oauthResources, err := oauth.Translate(identityProviders)
+			oauthResources, err := oauth.Translate(identityProviders, oauth.TokenConfig{})
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedCrd, oauthResources.OAuthCRD)
 		})

--- a/pkg/transform/oauth/ldap_test.go
+++ b/pkg/transform/oauth/ldap_test.go
@@ -50,9 +50,9 @@ func TestTransformMasterConfigLDAP(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resCrd, _, _, err := oauth.Translate(identityProviders)
+			oauthResources, err := oauth.Translate(identityProviders)
 			require.NoError(t, err)
-			assert.Equal(t, tc.expectedCrd, resCrd)
+			assert.Equal(t, tc.expectedCrd, oauthResources.OAuthCRD)
 		})
 	}
 }

--- a/pkg/transform/oauth/oauth.go
+++ b/pkg/transform/oauth/oauth.go
@@ -62,7 +62,7 @@ type Provider struct {
 	KeyFile    string `json:"keyFile"`
 }
 
-// IdentityProvider stroes an identity provider
+// IdentityProvider stores an identity provider
 type IdentityProvider struct {
 	Kind            string
 	APIVersion      string
@@ -78,6 +78,13 @@ type IdentityProvider struct {
 	UseAsLogin      bool
 }
 
+// Resources stores all oAuth config parts
+type Resources struct {
+	OAuthCRD   *CRD
+	Secrets    []*secrets.Secret
+	ConfigMaps []*configmaps.ConfigMap
+}
+
 const (
 	// APIVersion is the apiVersion string
 	APIVersion = "config.openshift.io/v1"
@@ -86,7 +93,7 @@ const (
 )
 
 // Translate converts OCPv3 OAuth to OCPv4 OAuth Custom Resources
-func Translate(identityProviders []IdentityProvider) (*CRD, []*secrets.Secret, []*configmaps.ConfigMap, error) {
+func Translate(identityProviders []IdentityProvider) (*Resources, error) {
 	var err error
 	var idP interface{}
 	var secretsSlice []*secrets.Secret
@@ -104,7 +111,7 @@ func Translate(identityProviders []IdentityProvider) (*CRD, []*secrets.Secret, [
 
 		p.Provider.Object, _, err = serializer.Decode(p.Provider.Raw, nil, nil)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, err
 		}
 
 		kind := p.Kind
@@ -158,7 +165,11 @@ func Translate(identityProviders []IdentityProvider) (*CRD, []*secrets.Secret, [
 		oauthCrd.Spec.IdentityProviders = append(oauthCrd.Spec.IdentityProviders, idP)
 	}
 
-	return &oauthCrd, secretsSlice, сonfigMapSlice, nil
+	return &Resources{
+		OAuthCRD:   &oauthCrd,
+		Secrets:    secretsSlice,
+		ConfigMaps: сonfigMapSlice,
+	}, nil
 }
 
 // Validate validate oauth providers

--- a/pkg/transform/oauth/oauth.go
+++ b/pkg/transform/oauth/oauth.go
@@ -85,6 +85,12 @@ type Resources struct {
 	ConfigMaps []*configmaps.ConfigMap
 }
 
+// TokenConfig store internal OAuth tokens duration
+type TokenConfig struct {
+	AuthorizeTokenMaxAgeSeconds int32
+	AccessTokenMaxAgeSeconds    int32
+}
+
 const (
 	// APIVersion is the apiVersion string
 	APIVersion = "config.openshift.io/v1"
@@ -93,12 +99,13 @@ const (
 )
 
 // Translate converts OCPv3 OAuth to OCPv4 OAuth Custom Resources
-func Translate(identityProviders []IdentityProvider) (*Resources, error) {
+func Translate(identityProviders []IdentityProvider, tokenConfig TokenConfig) (*Resources, error) {
 	var err error
 	var idP interface{}
 	var secretsSlice []*secrets.Secret
 	var сonfigMapSlice []*configmaps.ConfigMap
 
+	// Translate configuration of diffent oAuth providers to CRD, secrets and config maps
 	var oauthCrd CRD
 	oauthCrd.APIVersion = APIVersion
 	oauthCrd.Kind = "OAuth"
@@ -164,6 +171,9 @@ func Translate(identityProviders []IdentityProvider) (*Resources, error) {
 
 		oauthCrd.Spec.IdentityProviders = append(oauthCrd.Spec.IdentityProviders, idP)
 	}
+
+	// // Translate internal OAuth server’s token duration
+	// tokenConfigCR := buildTokenConfig()
 
 	return &Resources{
 		OAuthCRD:   &oauthCrd,

--- a/pkg/transform/oauth/oauth.go
+++ b/pkg/transform/oauth/oauth.go
@@ -35,7 +35,13 @@ type CRD struct {
 
 // Spec is a CRD Spec
 type Spec struct {
-	IdentityProviders []interface{} `yaml:"identityProviders"`
+	IdentityProviders []interface{}         `yaml:"identityProviders,omitempty"`
+	TokenConfig       TranslatedTokenConfig `yaml:"tokenConfig,omitempty"`
+}
+
+// TranslatedTokenConfig holds lifetime of access tokens
+type TranslatedTokenConfig struct {
+	AccessTokenMaxAgeSeconds int32 `yaml:"accessTokenMaxAgeSeconds"`
 }
 
 type identityProviderCommon struct {
@@ -172,8 +178,8 @@ func Translate(identityProviders []IdentityProvider, tokenConfig TokenConfig) (*
 		oauthCrd.Spec.IdentityProviders = append(oauthCrd.Spec.IdentityProviders, idP)
 	}
 
-	// // Translate internal OAuth server’s token duration
-	// tokenConfigCR := buildTokenConfig()
+	// Translate lifetime of access tokens
+	oauthCrd.Spec.TokenConfig.AccessTokenMaxAgeSeconds = tokenConfig.AccessTokenMaxAgeSeconds
 
 	return &Resources{
 		OAuthCRD:   &oauthCrd,

--- a/pkg/transform/oauth/oauth_test.go
+++ b/pkg/transform/oauth/oauth_test.go
@@ -58,7 +58,7 @@ func TestTransformMasterConfig(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			oauthResources, err := oauth.Translate(identityProviders)
+			oauthResources, err := oauth.Translate(identityProviders, oauth.TokenConfig{})
 			require.NoError(t, err)
 			assert.Equal(t, len(oauthResources.OAuthCRD.Spec.IdentityProviders), 9)
 			assert.Equal(t, oauthResources.OAuthCRD.Spec.IdentityProviders[0].(*oauth.IdentityProviderBasicAuth).Type, "BasicAuth")

--- a/pkg/transform/oauth/oauth_test.go
+++ b/pkg/transform/oauth/oauth_test.go
@@ -58,18 +58,18 @@ func TestTransformMasterConfig(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resCrd, _, _, err := oauth.Translate(identityProviders)
+			oauthResources, err := oauth.Translate(identityProviders)
 			require.NoError(t, err)
-			assert.Equal(t, len(resCrd.Spec.IdentityProviders), 9)
-			assert.Equal(t, resCrd.Spec.IdentityProviders[0].(*oauth.IdentityProviderBasicAuth).Type, "BasicAuth")
-			assert.Equal(t, resCrd.Spec.IdentityProviders[1].(*oauth.IdentityProviderGitHub).Type, "GitHub")
-			assert.Equal(t, resCrd.Spec.IdentityProviders[2].(*oauth.IdentityProviderGitLab).Type, "GitLab")
-			assert.Equal(t, resCrd.Spec.IdentityProviders[3].(*oauth.IdentityProviderGoogle).Type, "Google")
-			assert.Equal(t, resCrd.Spec.IdentityProviders[4].(*oauth.IdentityProviderHTPasswd).Type, "HTPasswd")
-			assert.Equal(t, resCrd.Spec.IdentityProviders[5].(*oauth.IdentityProviderKeystone).Type, "Keystone")
-			assert.Equal(t, resCrd.Spec.IdentityProviders[6].(*oauth.IdentityProviderLDAP).Type, "LDAP")
-			assert.Equal(t, resCrd.Spec.IdentityProviders[7].(*oauth.IdentityProviderRequestHeader).Type, "RequestHeader")
-			assert.Equal(t, resCrd.Spec.IdentityProviders[8].(*oauth.IdentityProviderOpenID).Type, "OpenID")
+			assert.Equal(t, len(oauthResources.OAuthCRD.Spec.IdentityProviders), 9)
+			assert.Equal(t, oauthResources.OAuthCRD.Spec.IdentityProviders[0].(*oauth.IdentityProviderBasicAuth).Type, "BasicAuth")
+			assert.Equal(t, oauthResources.OAuthCRD.Spec.IdentityProviders[1].(*oauth.IdentityProviderGitHub).Type, "GitHub")
+			assert.Equal(t, oauthResources.OAuthCRD.Spec.IdentityProviders[2].(*oauth.IdentityProviderGitLab).Type, "GitLab")
+			assert.Equal(t, oauthResources.OAuthCRD.Spec.IdentityProviders[3].(*oauth.IdentityProviderGoogle).Type, "Google")
+			assert.Equal(t, oauthResources.OAuthCRD.Spec.IdentityProviders[4].(*oauth.IdentityProviderHTPasswd).Type, "HTPasswd")
+			assert.Equal(t, oauthResources.OAuthCRD.Spec.IdentityProviders[5].(*oauth.IdentityProviderKeystone).Type, "Keystone")
+			assert.Equal(t, oauthResources.OAuthCRD.Spec.IdentityProviders[6].(*oauth.IdentityProviderLDAP).Type, "LDAP")
+			assert.Equal(t, oauthResources.OAuthCRD.Spec.IdentityProviders[7].(*oauth.IdentityProviderRequestHeader).Type, "RequestHeader")
+			assert.Equal(t, oauthResources.OAuthCRD.Spec.IdentityProviders[8].(*oauth.IdentityProviderOpenID).Type, "OpenID")
 		})
 	}
 

--- a/pkg/transform/oauth/oauth_test.go
+++ b/pkg/transform/oauth/oauth_test.go
@@ -58,18 +58,20 @@ func TestTransformMasterConfig(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			oauthResources, err := oauth.Translate(identityProviders, oauth.TokenConfig{})
+			oauthResources, err := oauth.Translate(identityProviders, oauth.TokenConfig{AccessTokenMaxAgeSeconds: 42000, AuthorizeTokenMaxAgeSeconds: 42000})
 			require.NoError(t, err)
-			assert.Equal(t, len(oauthResources.OAuthCRD.Spec.IdentityProviders), 9)
-			assert.Equal(t, oauthResources.OAuthCRD.Spec.IdentityProviders[0].(*oauth.IdentityProviderBasicAuth).Type, "BasicAuth")
-			assert.Equal(t, oauthResources.OAuthCRD.Spec.IdentityProviders[1].(*oauth.IdentityProviderGitHub).Type, "GitHub")
-			assert.Equal(t, oauthResources.OAuthCRD.Spec.IdentityProviders[2].(*oauth.IdentityProviderGitLab).Type, "GitLab")
-			assert.Equal(t, oauthResources.OAuthCRD.Spec.IdentityProviders[3].(*oauth.IdentityProviderGoogle).Type, "Google")
-			assert.Equal(t, oauthResources.OAuthCRD.Spec.IdentityProviders[4].(*oauth.IdentityProviderHTPasswd).Type, "HTPasswd")
-			assert.Equal(t, oauthResources.OAuthCRD.Spec.IdentityProviders[5].(*oauth.IdentityProviderKeystone).Type, "Keystone")
-			assert.Equal(t, oauthResources.OAuthCRD.Spec.IdentityProviders[6].(*oauth.IdentityProviderLDAP).Type, "LDAP")
-			assert.Equal(t, oauthResources.OAuthCRD.Spec.IdentityProviders[7].(*oauth.IdentityProviderRequestHeader).Type, "RequestHeader")
-			assert.Equal(t, oauthResources.OAuthCRD.Spec.IdentityProviders[8].(*oauth.IdentityProviderOpenID).Type, "OpenID")
+			assert.Equal(t, 9, len(oauthResources.OAuthCRD.Spec.IdentityProviders))
+			assert.Equal(t, "BasicAuth", oauthResources.OAuthCRD.Spec.IdentityProviders[0].(*oauth.IdentityProviderBasicAuth).Type)
+			assert.Equal(t, "GitHub", oauthResources.OAuthCRD.Spec.IdentityProviders[1].(*oauth.IdentityProviderGitHub).Type)
+			assert.Equal(t, "GitLab", oauthResources.OAuthCRD.Spec.IdentityProviders[2].(*oauth.IdentityProviderGitLab).Type)
+			assert.Equal(t, "Google", oauthResources.OAuthCRD.Spec.IdentityProviders[3].(*oauth.IdentityProviderGoogle).Type)
+			assert.Equal(t, "HTPasswd", oauthResources.OAuthCRD.Spec.IdentityProviders[4].(*oauth.IdentityProviderHTPasswd).Type)
+			assert.Equal(t, "Keystone", oauthResources.OAuthCRD.Spec.IdentityProviders[5].(*oauth.IdentityProviderKeystone).Type)
+			assert.Equal(t, "LDAP", oauthResources.OAuthCRD.Spec.IdentityProviders[6].(*oauth.IdentityProviderLDAP).Type)
+			assert.Equal(t, "RequestHeader", oauthResources.OAuthCRD.Spec.IdentityProviders[7].(*oauth.IdentityProviderRequestHeader).Type)
+			assert.Equal(t, "OpenID", oauthResources.OAuthCRD.Spec.IdentityProviders[8].(*oauth.IdentityProviderOpenID).Type)
+
+			assert.Equal(t, int32(42000), oauthResources.OAuthCRD.Spec.TokenConfig.AccessTokenMaxAgeSeconds)
 		})
 	}
 

--- a/pkg/transform/oauth/openid_test.go
+++ b/pkg/transform/oauth/openid_test.go
@@ -48,7 +48,7 @@ func TestTransformMasterConfigOpenID(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			oauthResources, err := oauth.Translate(identityProviders)
+			oauthResources, err := oauth.Translate(identityProviders, oauth.TokenConfig{})
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedCrd, oauthResources.OAuthCRD)
 		})

--- a/pkg/transform/oauth/openid_test.go
+++ b/pkg/transform/oauth/openid_test.go
@@ -48,9 +48,9 @@ func TestTransformMasterConfigOpenID(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resCrd, _, _, err := oauth.Translate(identityProviders)
+			oauthResources, err := oauth.Translate(identityProviders)
 			require.NoError(t, err)
-			assert.Equal(t, tc.expectedCrd, resCrd)
+			assert.Equal(t, tc.expectedCrd, oauthResources.OAuthCRD)
 		})
 	}
 }

--- a/pkg/transform/oauth/requestheader_test.go
+++ b/pkg/transform/oauth/requestheader_test.go
@@ -49,9 +49,9 @@ func TestTransformMasterConfigRequestHeader(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resCrd, _, _, err := oauth.Translate(identityProviders)
+			oauthResources, err := oauth.Translate(identityProviders)
 			require.NoError(t, err)
-			assert.Equal(t, tc.expectedCrd, resCrd)
+			assert.Equal(t, tc.expectedCrd, oauthResources.OAuthCRD)
 		})
 	}
 }

--- a/pkg/transform/oauth/requestheader_test.go
+++ b/pkg/transform/oauth/requestheader_test.go
@@ -49,7 +49,7 @@ func TestTransformMasterConfigRequestHeader(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			oauthResources, err := oauth.Translate(identityProviders)
+			oauthResources, err := oauth.Translate(identityProviders, oauth.TokenConfig{})
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedCrd, oauthResources.OAuthCRD)
 		})

--- a/pkg/transform/oauth_transform.go
+++ b/pkg/transform/oauth_transform.go
@@ -118,6 +118,23 @@ func (e OAuthExtraction) buildReportOutput() (Output, error) {
 		}
 	}
 
+	reportOutput.Reports = append(reportOutput.Reports,
+		Report{
+			Name:       "AccessTokenMaxAgeSeconds",
+			Kind:       "TokenConfig",
+			Supported:  true,
+			Confidence: "green",
+		})
+
+	reportOutput.Reports = append(reportOutput.Reports,
+		Report{
+			Name:       "AuthorizeTokenMaxAgeSeconds",
+			Kind:       "TokenConfig",
+			Supported:  false,
+			Confidence: "red",
+			Comment:    "Translation of AuthorizeTokenMaxAgeSeconds is not supported, it's value is 5 minutes in OCP4",
+		})
+
 	return reportOutput, nil
 }
 

--- a/pkg/transform/oauth_transform.go
+++ b/pkg/transform/oauth_transform.go
@@ -38,14 +38,14 @@ func (e OAuthExtraction) Transform() ([]Output, error) {
 func (e OAuthExtraction) buildManifestOutput() (Output, error) {
 	var ocp4Cluster Cluster
 
-	oauth, secrets, configMaps, err := oauth.Translate(e.IdentityProviders)
+	oauthResources, err := oauth.Translate(e.IdentityProviders)
 	if err != nil {
 		return nil, errors.New("Unable to generate OAuth CRD")
 	}
 
-	ocp4Cluster.Master.OAuth = *oauth
-	ocp4Cluster.Master.Secrets = secrets
-	ocp4Cluster.Master.ConfigMaps = configMaps
+	ocp4Cluster.Master.OAuth = *oauthResources.OAuthCRD
+	ocp4Cluster.Master.Secrets = oauthResources.Secrets
+	ocp4Cluster.Master.ConfigMaps = oauthResources.ConfigMaps
 
 	var manifests []Manifest
 	if ocp4Cluster.Master.OAuth.Kind != "" {

--- a/pkg/transform/oauth_transform_test.go
+++ b/pkg/transform/oauth_transform_test.go
@@ -4,9 +4,8 @@ import (
 	"encoding/base64"
 	"testing"
 
-	"github.com/fusor/cpma/pkg/transform/configmaps"
-
 	"github.com/fusor/cpma/pkg/transform"
+	"github.com/fusor/cpma/pkg/transform/configmaps"
 	"github.com/fusor/cpma/pkg/transform/oauth"
 	"github.com/fusor/cpma/pkg/transform/secrets"
 	cpmatest "github.com/fusor/cpma/pkg/utils/test"
@@ -257,6 +256,8 @@ func TestOAuthExtractionTransform(t *testing.T) {
 	expectedCrd.Spec.IdentityProviders = append(expectedCrd.Spec.IdentityProviders, requestHeaderIDP)
 	expectedCrd.Spec.IdentityProviders = append(expectedCrd.Spec.IdentityProviders, openidIDP)
 
+	expectedCrd.Spec.TokenConfig.AccessTokenMaxAgeSeconds = int32(86400)
+
 	expectedManifest, err := transform.GenYAML(expectedCrd)
 	require.NoError(t, err)
 	basicAuthCrtSecretManifest, err := transform.GenYAML(basicAuthCrtSecretCrd)
@@ -349,6 +350,10 @@ func TestOAuthExtractionTransform(t *testing.T) {
 
 			testExtraction := transform.OAuthExtraction{
 				IdentityProviders: identityProviders,
+				TokenConfig: oauth.TokenConfig{
+					AccessTokenMaxAgeSeconds:    int32(86400),
+					AuthorizeTokenMaxAgeSeconds: int32(500),
+				},
 			}
 
 			go func() {

--- a/pkg/transform/testdata/expected-bulk-test-masterconfig-oauth.yaml
+++ b/pkg/transform/testdata/expected-bulk-test-masterconfig-oauth.yaml
@@ -145,3 +145,5 @@ spec:
       urls:
         authorize: https://myidp.example.com/oauth2/authorize
         token: https://myidp.example.com/oauth2/token
+  tokenConfig:
+    accessTokenMaxAgeSeconds: 86400

--- a/pkg/transform/testdata/expected-omit-empty-masterconfig-oauth.yaml
+++ b/pkg/transform/testdata/expected-omit-empty-masterconfig-oauth.yaml
@@ -105,3 +105,5 @@ spec:
       urls:
         authorize: https://myidp.example.com/oauth2/authorize
         token: https://myidp.example.com/oauth2/token
+  tokenConfig:
+    accessTokenMaxAgeSeconds: 86400

--- a/pkg/transform/transform_test.go
+++ b/pkg/transform/transform_test.go
@@ -75,7 +75,7 @@ func TestOauthGenYAML(t *testing.T) {
 					})
 			}
 
-			oauthResources, err := oauth.Translate(identityProviders)
+			oauthResources, err := oauth.Translate(identityProviders, oauth.TokenConfig{})
 			require.NoError(t, err)
 
 			CRD, err := GenYAML(oauthResources.OAuthCRD)

--- a/pkg/transform/transform_test.go
+++ b/pkg/transform/transform_test.go
@@ -75,14 +75,14 @@ func TestOauthGenYAML(t *testing.T) {
 					})
 			}
 
-			crd, secrets, configMaps, err := oauth.Translate(identityProviders)
+			oauthResources, err := oauth.Translate(identityProviders)
 			require.NoError(t, err)
 
-			CRD, err := GenYAML(crd)
+			CRD, err := GenYAML(oauthResources.OAuthCRD)
 			require.NoError(t, err)
 
-			assert.Equal(t, tc.expectedSecretsLength, len(secrets))
-			assert.Equal(t, tc.expectedConfigMapsength, len(configMaps))
+			assert.Equal(t, tc.expectedSecretsLength, len(oauthResources.Secrets))
+			assert.Equal(t, tc.expectedConfigMapsength, len(oauthResources.ConfigMaps))
 			assert.Equal(t, expectedYaml, CRD)
 		})
 	}

--- a/pkg/transform/transform_test.go
+++ b/pkg/transform/transform_test.go
@@ -75,7 +75,10 @@ func TestOauthGenYAML(t *testing.T) {
 					})
 			}
 
-			oauthResources, err := oauth.Translate(identityProviders, oauth.TokenConfig{})
+			oauthResources, err := oauth.Translate(identityProviders, oauth.TokenConfig{
+				AccessTokenMaxAgeSeconds:    int32(86400),
+				AuthorizeTokenMaxAgeSeconds: int32(500),
+			})
 			require.NoError(t, err)
 
 			CRD, err := GenYAML(oauthResources.OAuthCRD)


### PR DESCRIPTION
We can translate `accessTokenMaxAgeSeconds` in token config and append it to oAuthCR, 
but `authorizeTokenMaxAgeSeconds` became unavailable for user.

https://github.com/openshift/cluster-authentication-operator/blob/6ae1bd829bfeccc2b5beafa98315211c8deb2da0/pkg/operator2/oauth.go#L138
https://docs.openshift.com/container-platform/3.11/install_config/configuring_authentication.html#token-options

 
