### PR TITLE
add crio transform

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -52,6 +52,7 @@ func InitConfig() error {
 	}
 	viperConfig.Set("home", home)
 
+	viperConfig.SetDefault("CrioConfigFile", "/etc/crio/crio.conf")
 	viperConfig.SetDefault("ETCDConfigFile", "/etc/etcd/etcd.conf")
 	viperConfig.SetDefault("MasterConfigFile", "/etc/origin/master/master-config.yaml")
 	viperConfig.SetDefault("NodeConfigFile", "/etc/origin/node/node-config.yaml")

--- a/pkg/transform/crio_transform.go
+++ b/pkg/transform/crio_transform.go
@@ -1,0 +1,194 @@
+package transform
+
+import (
+	"errors"
+
+	"github.com/BurntSushi/toml"
+	"github.com/fusor/cpma/pkg/env"
+	"github.com/fusor/cpma/pkg/io"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+)
+
+// CrioExtraction holds Crio data extracted from OCP3
+type CrioExtraction struct {
+	Crio Crio `toml:"crio"`
+}
+
+// Crio holds transformable/reportable content from crio.conf
+type Crio struct {
+	PidsLimit  int64  `toml:"pidsLimit"`
+	LogLevel   string `toml:"logLevel"`
+	LogSizeMax int64  `toml:"logSizeMax"`
+	InfraImage string `toml:"infraImage"`
+}
+
+// CrioCR is a is a Crio Cluster Resource
+type CrioCR struct {
+	APIVersion string       `yaml:"apiVersion"`
+	Kind       string       `yaml:"kind"`
+	Metadata   CrioMetadata `yaml:"metadata"`
+	Spec       CrioSpec     `yaml:"spec"`
+}
+
+// CrioMetadata is the Metadata for a Crio CR
+type CrioMetadata struct {
+	Name string
+}
+
+//CrioSpec is the Spec for a Crio CR
+type CrioSpec struct {
+	MachineConfigPoolSelector MachineConfigPoolSelector `yaml:"machineConfigPoolSelector"`
+	ContainerRuntimeConfig    ContainerRuntimeConfig    `yaml:"containerRuntimeConfig"`
+}
+
+// MachineConfigPoolSelector is the Pool Selector for a Machine Config
+type MachineConfigPoolSelector struct {
+	MatchLabels MatchLabels `yaml:"matchLabels"`
+}
+
+// MatchLabels matches the labels for a Pool Selector
+type MatchLabels struct {
+	CustomCrio string `yaml:"custom-crio"`
+}
+
+// ContainerRuntimeConfig contains a Crio Runtime Machine Config
+type ContainerRuntimeConfig struct {
+	PidsLimit  int64  `yaml:"pidsLimit,omitempty"`
+	LogLevel   string `yaml:"logLevel,omitempty"`
+	LogSizeMax int64  `yaml:"logSizeMax,omitempty"`
+	InfraImage string `yaml:"infraImage,omitempty"`
+}
+
+// CrioTransform is an Crio specific transform
+type CrioTransform struct {
+}
+
+// Transform converts data collected from an OCP3 into a useful output
+func (e CrioExtraction) Transform() ([]Output, error) {
+	logrus.Info("CrioTransform::Transform")
+	manifests, err := e.buildManifestOutput()
+	if err != nil {
+		return nil, err
+	}
+	reports, err := e.buildReportOutput()
+	if err != nil {
+		return nil, err
+	}
+	outputs := []Output{manifests, reports}
+	return outputs, nil
+}
+
+func (e CrioExtraction) buildManifestOutput() (Output, error) {
+	var manifests []Manifest
+
+	const (
+		apiVersion = "machineconfiguration.openshift.io/v1"
+		kind       = "ContainerRuntimeConfig"
+		name       = "set-log-and-pid"
+		annokey    = "release.openshift.io/create-only"
+		annoval    = "true"
+	)
+
+	var crioCR CrioCR
+	crioCR.APIVersion = apiVersion
+	crioCR.Kind = kind
+	crioCR.Metadata.Name = name
+	crioCR.Spec.MachineConfigPoolSelector.MatchLabels.CustomCrio = name
+	crioCR.Spec.ContainerRuntimeConfig.PidsLimit = e.Crio.PidsLimit
+	crioCR.Spec.ContainerRuntimeConfig.LogLevel = e.Crio.LogLevel
+	crioCR.Spec.ContainerRuntimeConfig.LogSizeMax = e.Crio.LogSizeMax
+	crioCR.Spec.ContainerRuntimeConfig.InfraImage = e.Crio.InfraImage
+
+	crioCRYAML, err := yaml.Marshal(&crioCR)
+	if err != nil {
+		return nil, err
+	}
+
+	manifest := Manifest{Name: "100_CPMA-crio-config.yaml", CRD: crioCRYAML}
+	manifests = append(manifests, manifest)
+
+	return ManifestOutput{
+		Manifests: manifests,
+	}, nil
+}
+
+func (e CrioExtraction) buildReportOutput() (Output, error) {
+	reportOutput := ReportOutput{
+		Component: CrioComponentName,
+	}
+
+	var confidence = "green"
+	var supported = true
+
+	if e.Crio.PidsLimit != 0 {
+		reportOutput.Reports = append(reportOutput.Reports,
+			Report{
+				Name:       "pidsLimit",
+				Kind:       "Configuration",
+				Supported:  supported,
+				Confidence: confidence,
+			})
+	}
+	if e.Crio.LogLevel != "" {
+		reportOutput.Reports = append(reportOutput.Reports,
+			Report{
+				Name:       "logLevel",
+				Kind:       "Configuration",
+				Supported:  supported,
+				Confidence: confidence,
+			})
+	}
+	if e.Crio.LogSizeMax != 0 {
+		reportOutput.Reports = append(reportOutput.Reports,
+			Report{
+				Name:       "logSizeMax",
+				Kind:       "Configuration",
+				Supported:  supported,
+				Confidence: confidence,
+			})
+	}
+	if e.Crio.InfraImage != "" {
+		reportOutput.Reports = append(reportOutput.Reports,
+			Report{
+				Name:       "infrImage",
+				Kind:       "Configuration",
+				Supported:  supported,
+				Confidence: confidence,
+			})
+	}
+
+	return reportOutput, nil
+}
+
+// Extract collects Crio configuration from an OCP3 cluster
+func (e CrioTransform) Extract() (Extraction, error) {
+	logrus.Info("CrioTransform::Extract")
+	content, err := io.FetchFile(env.Config().GetString("CrioConfigFile"))
+	if err != nil {
+		return nil, err
+	}
+
+	var extraction CrioExtraction
+	if _, err := toml.Decode(string(content), &extraction); err != nil {
+		return nil, err
+	}
+	return extraction, nil
+}
+
+// Validate confirms we have recieved good Crio configuration data during Extract
+func (e CrioExtraction) Validate() error {
+	if e.Crio.PidsLimit == 0 &&
+		e.Crio.LogSizeMax == 0 &&
+		e.Crio.LogLevel == "" &&
+		e.Crio.InfraImage == "" {
+		return errors.New("no supported crio configuration found")
+	}
+
+	return nil
+}
+
+// Name returns a human readable name for the transform
+func (e CrioTransform) Name() string {
+	return "Crio"
+}

--- a/pkg/transform/crio_transform_test.go
+++ b/pkg/transform/crio_transform_test.go
@@ -1,0 +1,129 @@
+package transform_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/fusor/cpma/pkg/transform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func loadCrioExtraction() (transform.CrioExtraction, error) {
+	// TODO: Something is broken here in a way that it's causing the translaters
+	// to fail. Need some help with creating test identiy providers in a way
+	// that won't crash the translator
+
+	// Build example identity providers, this is straight copy pasted from
+	// oauth test, IMO this loading of example identity providers should be
+	// some shared test helper
+	file := "testdata/crio.conf" // File copied into transform pkg testdata
+	content, _ := ioutil.ReadFile(file)
+	var extraction transform.CrioExtraction
+	_, err := toml.Decode(string(content), &extraction)
+
+	return extraction, err
+}
+
+func TestCrioExtractionTransform(t *testing.T) {
+	var expectedManifests []transform.Manifest
+
+	var expectedCrd transform.CrioCR
+	expectedCrd.APIVersion = "machineconfiguration.openshift.io/v1"
+	expectedCrd.Kind = "ContainerRuntimeConfig"
+	expectedCrd.Metadata.Name = "set-log-and-pid"
+	expectedCrd.Spec.MachineConfigPoolSelector.MatchLabels.CustomCrio = "set-log-and-pid"
+	expectedCrd.Spec.ContainerRuntimeConfig.PidsLimit = 2048
+	expectedCrd.Spec.ContainerRuntimeConfig.LogLevel = "debug"
+	expectedCrd.Spec.ContainerRuntimeConfig.LogSizeMax = 100000
+	expectedCrd.Spec.ContainerRuntimeConfig.InfraImage = "image/infraImage:1"
+
+	crioCRYAML, err := yaml.Marshal(&expectedCrd)
+	require.NoError(t, err)
+
+	expectedManifests = append(expectedManifests,
+		transform.Manifest{Name: "100_CPMA-crio-config.yaml", CRD: crioCRYAML})
+
+	expectedReport := transform.ReportOutput{
+		Component: "Crio",
+	}
+
+	expectedReport.Reports = append(expectedReport.Reports,
+		transform.Report{
+			Name:       "pidsLimit",
+			Kind:       "Configuration",
+			Supported:  true,
+			Confidence: "green",
+		})
+	expectedReport.Reports = append(expectedReport.Reports,
+		transform.Report{
+			Name:       "logLevel",
+			Kind:       "Configuration",
+			Supported:  true,
+			Confidence: "green",
+		})
+	expectedReport.Reports = append(expectedReport.Reports,
+		transform.Report{
+			Name:       "logSizeMax",
+			Kind:       "Configuration",
+			Supported:  true,
+			Confidence: "green",
+		})
+	expectedReport.Reports = append(expectedReport.Reports,
+		transform.Report{
+			Name:       "infrImage",
+			Kind:       "Configuration",
+			Supported:  true,
+			Confidence: "green",
+		})
+
+	testCases := []struct {
+		name              string
+		expectedManifests []transform.Manifest
+		expectedReports   transform.ReportOutput
+	}{
+		{
+			name:              "transform crio extraction",
+			expectedManifests: expectedManifests,
+			expectedReports:   expectedReport,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualManifestsChan := make(chan []transform.Manifest)
+			actualReportsChan := make(chan transform.ReportOutput)
+
+			// Override flush method
+			transform.ManifestOutputFlush = func(manifests []transform.Manifest) error {
+				actualManifestsChan <- manifests
+				return nil
+			}
+			transform.ReportOutputFlush = func(reports transform.ReportOutput) error {
+				actualReportsChan <- reports
+				return nil
+			}
+
+			testExtraction, err := loadCrioExtraction()
+			require.NoError(t, err)
+
+			go func() {
+				transformOutput, err := testExtraction.Transform()
+				if err != nil {
+					t.Error(err)
+				}
+				for _, output := range transformOutput {
+					output.Flush()
+				}
+			}()
+
+			actualManifests := <-actualManifestsChan
+			assert.Equal(t, actualManifests, tc.expectedManifests)
+			actualReports := <-actualReportsChan
+			assert.Equal(t, actualReports, tc.expectedReports)
+		})
+
+	}
+}

--- a/pkg/transform/report_output.go
+++ b/pkg/transform/report_output.go
@@ -14,7 +14,7 @@ type ReportOutput struct {
 }
 
 // ReportOutputFlush flush reports to disk
-var reportOutputFlush = func(r ReportOutput) error {
+var ReportOutputFlush = func(r ReportOutput) error {
 	logrus.Info("Flushing reports to disk")
 	DumpReports(r)
 	return nil
@@ -22,7 +22,7 @@ var reportOutputFlush = func(r ReportOutput) error {
 
 // Flush reports to files
 func (r ReportOutput) Flush() error {
-	return reportOutputFlush(r)
+	return ReportOutputFlush(r)
 }
 
 // DumpReports creates OCDs files

--- a/pkg/transform/testdata/crio.conf
+++ b/pkg/transform/testdata/crio.conf
@@ -1,0 +1,5 @@
+[crio]
+pidsLimit = 2048
+logLevel = "debug"
+logSizeMax = 100000
+infraImage = "image/infraImage:1"

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -21,6 +21,9 @@ const (
 	// APIComponentName is the API component string
 	APIComponentName = "API"
 
+	// CrioComponentName is the Crio component string
+	CrioComponentName = "Crio"
+
 	// ETCDComponentName is the ETCD component string
 	ETCDComponentName = "ETCD"
 
@@ -90,6 +93,7 @@ func Start() {
 
 	runner.Transform([]Transform{
 		APITransform{},
+		CrioTransform{},
 		ETCDTransform{},
 		OAuthTransform{},
 		SDNTransform{},


### PR DESCRIPTION
crio.conf is unlikely to exist in many clusters as docker was the default runtime, so it's very likely unless you add a crio.conf that you'll see a warning that the file cannot be downloaded.

If it does exist however normal processing should occur.