### PR TITLE
Add docker report

### DIFF
--- a/pkg/transform/docker_transform.go
+++ b/pkg/transform/docker_transform.go
@@ -1,0 +1,61 @@
+package transform
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+// DockerComponentName is the Docker component string
+const DockerComponentName = "Docker"
+
+// DockerExtraction holds Docker data extracted from OCP3
+type DockerExtraction struct {
+}
+
+// DockerTransform is an Docker specific transform
+type DockerTransform struct {
+}
+
+// Transform converts data collected from an OCP3 into a useful output
+func (e DockerExtraction) Transform() ([]Output, error) {
+	logrus.Info("DockerTransform::Transform")
+	reports, err := e.buildReportOutput()
+	if err != nil {
+		return nil, err
+	}
+	outputs := []Output{reports}
+	return outputs, nil
+}
+
+func (e DockerExtraction) buildReportOutput() (Output, error) {
+	reportOutput := ReportOutput{
+		Component: DockerComponentName,
+	}
+
+	reportOutput.Reports = append(reportOutput.Reports,
+		Report{
+			Name:       "Docker",
+			Kind:       "Container Runtime",
+			Supported:  false,
+			Confidence: NoConfidence,
+			Comment:    "The Docker runtime has been replaced with CRI-O",
+		})
+
+	return reportOutput, nil
+}
+
+// Extract collects Docker configuration from an OCP3 cluster
+func (e DockerTransform) Extract() (Extraction, error) {
+	logrus.Info("DockerTransform::Extract")
+	var extraction DockerExtraction
+	return extraction, nil
+}
+
+// Validate confirms we have recieved good Docker configuration data during Extract
+func (e DockerExtraction) Validate() error {
+	return nil
+}
+
+// Name returns a human readable name for the transform
+func (e DockerTransform) Name() string {
+	return DockerComponentName
+}

--- a/pkg/transform/docker_transform_test.go
+++ b/pkg/transform/docker_transform_test.go
@@ -1,0 +1,68 @@
+package transform_test
+
+import (
+	"testing"
+
+	"github.com/fusor/cpma/pkg/transform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func loadDockerExtraction() (transform.DockerExtraction, error) {
+	var extraction transform.DockerExtraction
+	return extraction, nil
+}
+
+func TestDockerExtractionTransform(t *testing.T) {
+
+	expectedReport := transform.ReportOutput{
+		Component: "Docker",
+	}
+
+	expectedReport.Reports = append(expectedReport.Reports,
+		transform.Report{
+			Name:       "Docker",
+			Kind:       "Container Runtime",
+			Supported:  false,
+			Confidence: 0,
+			Comment:    "The Docker runtime has been replaced with CRI-O",
+		})
+	testCases := []struct {
+		name            string
+		expectedReports transform.ReportOutput
+	}{
+		{
+			name:            "transform crio extraction",
+			expectedReports: expectedReport,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualReportsChan := make(chan transform.ReportOutput)
+
+			// Override flush method
+			transform.ReportOutputFlush = func(reports transform.ReportOutput) error {
+				actualReportsChan <- reports
+				return nil
+			}
+
+			testExtraction, err := loadDockerExtraction()
+			require.NoError(t, err)
+
+			go func() {
+				transformOutput, err := testExtraction.Transform()
+				if err != nil {
+					t.Error(err)
+				}
+				for _, output := range transformOutput {
+					output.Flush()
+				}
+			}()
+
+			actualReports := <-actualReportsChan
+			assert.Equal(t, actualReports, tc.expectedReports)
+		})
+
+	}
+}

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -85,6 +85,7 @@ func Start() {
 	runner.Transform([]Transform{
 		APITransform{},
 		CrioTransform{},
+		DockerTransform{},
 		ETCDTransform{},
 		OAuthTransform{},
 		SDNTransform{},


### PR DESCRIPTION
It's technically possible to have just crio installed in a 3.x cluster, so it may be worth looking for a file owned by the docker package to see if it's installed (and likely being used), but as far as I know the only way to determine if either or both is in use is by looking at the labels for all nodes, so I'm not sure that gives us the full picture either.