### PR TITLE
Improve report messages

### DIFF
--- a/pkg/transform/oauth_transform.go
+++ b/pkg/transform/oauth_transform.go
@@ -3,6 +3,7 @@ package transform
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/fusor/cpma/pkg/decode"
 	"github.com/fusor/cpma/pkg/env"
@@ -105,18 +106,20 @@ func (e OAuthExtraction) buildReportOutput() (Output, error) {
 			"BasicAuthPasswordIdentityProvider":
 			reportOutput.Reports = append(reportOutput.Reports,
 				Report{
-					Name:       p.Name,
-					Kind:       p.Kind,
+					Name:       p.Kind,
+					Kind:       "IdentityProviders",
 					Supported:  true,
 					Confidence: HighConfidence,
+					Comment:    fmt.Sprintf("Identity provider %s is supported in OCP4", p.Name),
 				})
 		default:
 			reportOutput.Reports = append(reportOutput.Reports,
 				Report{
-					Name:       p.Name,
-					Kind:       p.Kind,
+					Name:       p.Kind,
+					Kind:       "IdentityProviders",
 					Supported:  false,
 					Confidence: NoConfidence,
+					Comment:    fmt.Sprintf("Identity provider %s is not supported in OCP4", p.Name),
 				})
 		}
 	}
@@ -140,7 +143,7 @@ func (e OAuthExtraction) buildReportOutput() (Output, error) {
 
 	reportOutput.Reports = append(reportOutput.Reports,
 		Report{
-			Name:       "AssetPublicURL",
+			Name:       "",
 			Kind:       "AssetPublicURL",
 			Supported:  false,
 			Confidence: NoConfidence,
@@ -149,7 +152,7 @@ func (e OAuthExtraction) buildReportOutput() (Output, error) {
 
 	reportOutput.Reports = append(reportOutput.Reports,
 		Report{
-			Name:       "MasterPublicURL",
+			Name:       "",
 			Kind:       "MasterPublicURL",
 			Supported:  false,
 			Confidence: NoConfidence,
@@ -158,7 +161,7 @@ func (e OAuthExtraction) buildReportOutput() (Output, error) {
 
 	reportOutput.Reports = append(reportOutput.Reports,
 		Report{
-			Name:       "MasterCA",
+			Name:       "",
 			Kind:       "MasterCA",
 			Supported:  false,
 			Confidence: NoConfidence,
@@ -167,7 +170,7 @@ func (e OAuthExtraction) buildReportOutput() (Output, error) {
 
 	reportOutput.Reports = append(reportOutput.Reports,
 		Report{
-			Name:       "MasterURL",
+			Name:       "",
 			Kind:       "MasterURL",
 			Supported:  false,
 			Confidence: NoConfidence,
@@ -176,8 +179,8 @@ func (e OAuthExtraction) buildReportOutput() (Output, error) {
 
 	reportOutput.Reports = append(reportOutput.Reports,
 		Report{
+			Name:       "",
 			Kind:       "GrantConfig",
-			Name:       "GrantConfig",
 			Supported:  false,
 			Confidence: NoConfidence,
 			Comment:    "Translation of GrantConfig is not supported",
@@ -185,8 +188,8 @@ func (e OAuthExtraction) buildReportOutput() (Output, error) {
 
 	reportOutput.Reports = append(reportOutput.Reports,
 		Report{
+			Name:       "",
 			Kind:       "SessionConfig",
-			Name:       "SessionConfig",
 			Supported:  false,
 			Confidence: NoConfidence,
 			Comment:    "Translation of SessionConfig is not supported",

--- a/pkg/transform/oauth_transform_test.go
+++ b/pkg/transform/oauth_transform_test.go
@@ -330,66 +330,75 @@ func TestOAuthExtractionTransform(t *testing.T) {
 	}
 	expectedReport.Reports = append(expectedReport.Reports,
 		transform.Report{
-			Name:       "my_remote_basic_auth_provider",
-			Kind:       "BasicAuthPasswordIdentityProvider",
+			Name:       "BasicAuthPasswordIdentityProvider",
+			Kind:       "IdentityProviders",
 			Supported:  true,
 			Confidence: 2,
+			Comment:    "Identity provider my_remote_basic_auth_provider is supported in OCP4",
 		})
 	expectedReport.Reports = append(expectedReport.Reports,
 		transform.Report{
-			Name:       "github123456789",
-			Kind:       "GitHubIdentityProvider",
+			Name:       "GitHubIdentityProvider",
+			Kind:       "IdentityProviders",
 			Supported:  true,
 			Confidence: 2,
+			Comment:    "Identity provider github123456789 is supported in OCP4",
 		})
 	expectedReport.Reports = append(expectedReport.Reports,
 		transform.Report{
-			Name:       "gitlab123456789",
-			Kind:       "GitLabIdentityProvider",
+			Name:       "GitLabIdentityProvider",
+			Kind:       "IdentityProviders",
 			Supported:  true,
 			Confidence: 2,
+			Comment:    "Identity provider gitlab123456789 is supported in OCP4",
 		})
 	expectedReport.Reports = append(expectedReport.Reports,
 		transform.Report{
-			Name:       "google123456789123456789",
-			Kind:       "GoogleIdentityProvider",
+			Name:       "GoogleIdentityProvider",
+			Kind:       "IdentityProviders",
 			Supported:  true,
 			Confidence: 2,
+			Comment:    "Identity provider google123456789123456789 is supported in OCP4",
 		})
 	expectedReport.Reports = append(expectedReport.Reports,
 		transform.Report{
-			Name:       "htpasswd_auth",
-			Kind:       "HTPasswdPasswordIdentityProvider",
+			Name:       "HTPasswdPasswordIdentityProvider",
+			Kind:       "IdentityProviders",
 			Supported:  true,
 			Confidence: 2,
+			Comment:    "Identity provider htpasswd_auth is supported in OCP4",
 		})
 	expectedReport.Reports = append(expectedReport.Reports,
 		transform.Report{
-			Name:       "my_keystone_provider",
-			Kind:       "KeystonePasswordIdentityProvider",
+			Name:       "KeystonePasswordIdentityProvider",
+			Kind:       "IdentityProviders",
 			Supported:  true,
 			Confidence: 2,
+			Comment:    "Identity provider my_keystone_provider is supported in OCP4",
 		})
 	expectedReport.Reports = append(expectedReport.Reports,
 		transform.Report{
-			Name:       "my_ldap_provider",
-			Kind:       "LDAPPasswordIdentityProvider",
+			Name:       "LDAPPasswordIdentityProvider",
+			Kind:       "IdentityProviders",
 			Supported:  true,
 			Confidence: 2,
+			Comment:    "Identity provider my_ldap_provider is supported in OCP4",
 		})
 	expectedReport.Reports = append(expectedReport.Reports,
 		transform.Report{
-			Name:       "my_request_header_provider",
-			Kind:       "RequestHeaderIdentityProvider",
+			Name:       "RequestHeaderIdentityProvider",
+			Kind:       "IdentityProviders",
 			Supported:  true,
 			Confidence: 2,
+			Comment:    "Identity provider my_request_header_provider is supported in OCP4",
 		})
 	expectedReport.Reports = append(expectedReport.Reports,
 		transform.Report{
-			Name:       "my_openid_connect",
-			Kind:       "OpenIDIdentityProvider",
+			Name:       "OpenIDIdentityProvider",
+			Kind:       "IdentityProviders",
 			Supported:  true,
 			Confidence: 2,
+			Comment:    "Identity provider my_openid_connect is supported in OCP4",
 		})
 	expectedReport.Reports = append(expectedReport.Reports,
 		transform.Report{
@@ -408,7 +417,7 @@ func TestOAuthExtractionTransform(t *testing.T) {
 		})
 	expectedReport.Reports = append(expectedReport.Reports,
 		transform.Report{
-			Name:       "AssetPublicURL",
+			Name:       "",
 			Kind:       "AssetPublicURL",
 			Supported:  false,
 			Confidence: 0,
@@ -416,7 +425,7 @@ func TestOAuthExtractionTransform(t *testing.T) {
 		})
 	expectedReport.Reports = append(expectedReport.Reports,
 		transform.Report{
-			Name:       "MasterPublicURL",
+			Name:       "",
 			Kind:       "MasterPublicURL",
 			Supported:  false,
 			Confidence: 0,
@@ -424,7 +433,7 @@ func TestOAuthExtractionTransform(t *testing.T) {
 		})
 	expectedReport.Reports = append(expectedReport.Reports,
 		transform.Report{
-			Name:       "MasterCA",
+			Name:       "",
 			Kind:       "MasterCA",
 			Supported:  false,
 			Confidence: 0,
@@ -432,7 +441,7 @@ func TestOAuthExtractionTransform(t *testing.T) {
 		})
 	expectedReport.Reports = append(expectedReport.Reports,
 		transform.Report{
-			Name:       "MasterURL",
+			Name:       "",
 			Kind:       "MasterURL",
 			Supported:  false,
 			Confidence: 0,
@@ -440,16 +449,16 @@ func TestOAuthExtractionTransform(t *testing.T) {
 		})
 	expectedReport.Reports = append(expectedReport.Reports,
 		transform.Report{
+			Name:       "",
 			Kind:       "GrantConfig",
-			Name:       "GrantConfig",
 			Supported:  false,
 			Confidence: 0,
 			Comment:    "Translation of GrantConfig is not supported",
 		})
 	expectedReport.Reports = append(expectedReport.Reports,
 		transform.Report{
+			Name:       "",
 			Kind:       "SessionConfig",
-			Name:       "SessionConfig",
 			Supported:  false,
 			Confidence: 0,
 			Comment:    "Translation of SessionConfig is not supported",

--- a/pkg/transform/sdn_transform.go
+++ b/pkg/transform/sdn_transform.go
@@ -1,7 +1,7 @@
 package transform
 
 import (
-	"strconv"
+	"fmt"
 
 	"github.com/fusor/cpma/pkg/decode"
 	"github.com/fusor/cpma/pkg/env"
@@ -68,21 +68,23 @@ func (e SDNExtraction) buildReportOutput() (Output, error) {
 	}
 
 	for _, n := range e.MasterConfig.NetworkConfig.ClusterNetworks {
+		cidrComment := fmt.Sprintf("Networks must be configured during installation, it's possible to use %s", n.CIDR)
 		reportOutput.Reports = append(reportOutput.Reports,
 			Report{
-				Name:       n.CIDR,
+				Name:       "CIDR",
 				Kind:       "ClusterNetwork",
 				Supported:  true,
 				Confidence: ModerateConfidence,
-				Comment:    clusterNetworkComment,
+				Comment:    cidrComment,
 			})
+
 		reportOutput.Reports = append(reportOutput.Reports,
 			Report{
-				Name:       strconv.Itoa(int(n.HostSubnetLength)),
+				Name:       "HostSubnetLength",
 				Kind:       "ClusterNetwork",
 				Supported:  false,
 				Confidence: NoConfidence,
-				Comment:    "hostSubnetLength is not supported in OCP4",
+				Comment:    clusterNetworkComment,
 			})
 	}
 
@@ -95,20 +97,18 @@ func (e SDNExtraction) buildReportOutput() (Output, error) {
 			Comment:    "Networks must be configured during installation",
 		})
 
-	for _, externalCIDR := range e.MasterConfig.NetworkConfig.ExternalIPNetworkCIDRs {
-		reportOutput.Reports = append(reportOutput.Reports,
-			Report{
-				Name:       externalCIDR,
-				Kind:       "ExternalIPNetworkCIDRs",
-				Supported:  false,
-				Confidence: NoConfidence,
-				Comment:    "Configuration of ExternalIPNetworkCIDRs is not supported in OCP4",
-			})
-	}
+	reportOutput.Reports = append(reportOutput.Reports,
+		Report{
+			Name:       "",
+			Kind:       "ExternalIPNetworkCIDRs",
+			Supported:  false,
+			Confidence: NoConfidence,
+			Comment:    "Configuration of ExternalIPNetworkCIDRs is not supported in OCP4",
+		})
 
 	reportOutput.Reports = append(reportOutput.Reports,
 		Report{
-			Name:       e.MasterConfig.NetworkConfig.IngressIPNetworkCIDR,
+			Name:       "",
 			Kind:       "IngressIPNetworkCIDR",
 			Supported:  false,
 			Confidence: NoConfidence,

--- a/pkg/transform/sdn_transform_test.go
+++ b/pkg/transform/sdn_transform_test.go
@@ -33,19 +33,20 @@ func TestSDNExtractionTransform(t *testing.T) {
 	}
 	expectedReport.Reports = append(expectedReport.Reports,
 		transform.Report{
-			Name:       "10.128.0.0/14",
+			Name:       "CIDR",
 			Kind:       "ClusterNetwork",
 			Supported:  true,
 			Confidence: 1,
-			Comment:    "Networks must be configured during installation,\n hostSubnetLength was replaced with hostPrefix in OCP4, default value was set to 23",
+			Comment:    "Networks must be configured during installation, it's possible to use 10.128.0.0/14",
 		})
+
 	expectedReport.Reports = append(expectedReport.Reports,
 		transform.Report{
-			Name:       "9",
+			Name:       "HostSubnetLength",
 			Kind:       "ClusterNetwork",
 			Supported:  false,
 			Confidence: 0,
-			Comment:    "hostSubnetLength is not supported in OCP4",
+			Comment:    "Networks must be configured during installation,\n hostSubnetLength was replaced with hostPrefix in OCP4, default value was set to 23",
 		})
 	expectedReport.Reports = append(expectedReport.Reports,
 		transform.Report{
@@ -57,7 +58,7 @@ func TestSDNExtractionTransform(t *testing.T) {
 		})
 	expectedReport.Reports = append(expectedReport.Reports,
 		transform.Report{
-			Name:       "0.0.0.0/0",
+			Name:       "",
 			Kind:       "ExternalIPNetworkCIDRs",
 			Supported:  false,
 			Confidence: 0,


### PR DESCRIPTION
This PR improves report, in my opinion some parts of report don't properly match master config yaml.

I think if yaml looks like this:
```
tokenConfig:
  accessTokenMaxAgeSeconds: 123
  authorizeTokenMaxAgeSeconds: 123
```

`Name` field in report should match `accessTokenMaxAgeSeconds` and `Kind` should be `tokenConfig` so report json will look like this:
```
{
	"name": "AccessTokenMaxAgeSeconds",
	"kind": "TokenConfig",
	"supported": true,
	"confidence": "green",
	"comment": ""
},
{
	"name": "AuthorizeTokenMaxAgeSeconds",
	"kind": "TokenConfig",
	"supported": false,
	"confidence": "red",
	"comment": "Translation of AuthorizeTokenMaxAgeSeconds is not supported, it's value is 5 minutes in OCP4"
}
```