### PR TITLE
Rename configv1 to legacyconfigv1

### DIFF
--- a/pkg/decode/decode.go
+++ b/pkg/decode/decode.go
@@ -3,18 +3,18 @@ package decode
 import (
 	"k8s.io/client-go/kubernetes/scheme"
 
-	configv1 "github.com/openshift/api/legacyconfig/v1"
+	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	k8sjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
 func init() {
-	configv1.InstallLegacy(scheme.Scheme)
+	legacyconfigv1.InstallLegacy(scheme.Scheme)
 }
 
 // MasterConfig unmarshals OCP3 Master
 // There is no known differences between OCP3 minor versions of the master config
-func MasterConfig(content []byte) (*configv1.MasterConfig, error) {
-	var masterConfig = new(configv1.MasterConfig)
+func MasterConfig(content []byte) (*legacyconfigv1.MasterConfig, error) {
+	var masterConfig = new(legacyconfigv1.MasterConfig)
 
 	serializer := k8sjson.NewYAMLSerializer(k8sjson.DefaultMetaFactory, scheme.Scheme, scheme.Scheme)
 	_, _, err := serializer.Decode(content, nil, masterConfig)
@@ -27,8 +27,8 @@ func MasterConfig(content []byte) (*configv1.MasterConfig, error) {
 
 // NodeConfig unmarshals OCP3 Node
 // Unknown differences between OCP3 minor versions of the node config
-func NodeConfig(content []byte) (*configv1.NodeConfig, error) {
-	var nodeConfig = new(configv1.NodeConfig)
+func NodeConfig(content []byte) (*legacyconfigv1.NodeConfig, error) {
+	var nodeConfig = new(legacyconfigv1.NodeConfig)
 	serializer := k8sjson.NewYAMLSerializer(k8sjson.DefaultMetaFactory, scheme.Scheme, scheme.Scheme)
 	_, _, err := serializer.Decode(content, nil, nodeConfig)
 	if err != nil {

--- a/pkg/io/io.go
+++ b/pkg/io/io.go
@@ -11,7 +11,7 @@ import (
 	"github.com/fusor/cpma/pkg/io/remotehost"
 	"github.com/sirupsen/logrus"
 
-	configv1 "github.com/openshift/api/legacyconfig/v1"
+	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 )
 
 // FetchFile first tries to retrieve file from local disk (outputDir/<Hostname>/).
@@ -44,7 +44,7 @@ func FetchEnv(host, envVar string) (string, error) {
 }
 
 // FetchStringSource fetches a string from an OCP3 cluster
-func FetchStringSource(stringSource configv1.StringSource) (string, error) {
+func FetchStringSource(stringSource legacyconfigv1.StringSource) (string, error) {
 	if stringSource.Value != "" {
 		return stringSource.Value, nil
 	}

--- a/pkg/transform/oauth/basicauth.go
+++ b/pkg/transform/oauth/basicauth.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/fusor/cpma/pkg/transform/configmaps"
 	"github.com/fusor/cpma/pkg/transform/secrets"
-	configv1 "github.com/openshift/api/legacyconfig/v1"
+	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
@@ -31,7 +31,7 @@ func buildBasicAuthIP(serializer *json.Serializer, p IdentityProvider) (*Identit
 		idP                   = &IdentityProviderBasicAuth{}
 		certSecret, keySecret *secrets.Secret
 		caConfigmap           *configmaps.ConfigMap
-		basicAuth             configv1.BasicAuthPasswordIdentityProvider
+		basicAuth             legacyconfigv1.BasicAuthPasswordIdentityProvider
 	)
 
 	_, _, err = serializer.Decode(p.Provider.Raw, nil, &basicAuth)
@@ -75,7 +75,7 @@ func buildBasicAuthIP(serializer *json.Serializer, p IdentityProvider) (*Identit
 }
 
 func validateBasicAuthProvider(serializer *json.Serializer, p IdentityProvider) error {
-	var basicAuth configv1.BasicAuthPasswordIdentityProvider
+	var basicAuth legacyconfigv1.BasicAuthPasswordIdentityProvider
 
 	_, _, err := serializer.Decode(p.Provider.Raw, nil, &basicAuth)
 	if err != nil {

--- a/pkg/transform/oauth/github.go
+++ b/pkg/transform/oauth/github.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fusor/cpma/pkg/io"
 	"github.com/fusor/cpma/pkg/transform/configmaps"
 	"github.com/fusor/cpma/pkg/transform/secrets"
-	configv1 "github.com/openshift/api/legacyconfig/v1"
+	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
@@ -33,7 +33,7 @@ func buildGitHubIP(serializer *json.Serializer, p IdentityProvider) (*IdentityPr
 		idP         = &IdentityProviderGitHub{}
 		secret      *secrets.Secret
 		caConfigmap *configmaps.ConfigMap
-		github      configv1.GitHubIdentityProvider
+		github      legacyconfigv1.GitHubIdentityProvider
 	)
 
 	_, _, err = serializer.Decode(p.Provider.Raw, nil, &github)
@@ -73,7 +73,7 @@ func buildGitHubIP(serializer *json.Serializer, p IdentityProvider) (*IdentityPr
 }
 
 func validateGithubProvider(serializer *json.Serializer, p IdentityProvider) error {
-	var github configv1.GitHubIdentityProvider
+	var github legacyconfigv1.GitHubIdentityProvider
 
 	_, _, err := serializer.Decode(p.Provider.Raw, nil, &github)
 	if err != nil {

--- a/pkg/transform/oauth/gitlab.go
+++ b/pkg/transform/oauth/gitlab.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fusor/cpma/pkg/io"
 	"github.com/fusor/cpma/pkg/transform/configmaps"
 	"github.com/fusor/cpma/pkg/transform/secrets"
-	configv1 "github.com/openshift/api/legacyconfig/v1"
+	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
@@ -31,7 +31,7 @@ func buildGitLabIP(serializer *json.Serializer, p IdentityProvider) (*IdentityPr
 		idP         = &IdentityProviderGitLab{}
 		secret      *secrets.Secret
 		caConfigmap *configmaps.ConfigMap
-		gitlab      configv1.GitLabIdentityProvider
+		gitlab      legacyconfigv1.GitLabIdentityProvider
 	)
 	_, _, err = serializer.Decode(p.Provider.Raw, nil, &gitlab)
 	if err != nil {
@@ -68,7 +68,7 @@ func buildGitLabIP(serializer *json.Serializer, p IdentityProvider) (*IdentityPr
 }
 
 func validateGitLabProvider(serializer *json.Serializer, p IdentityProvider) error {
-	var gitlab configv1.GitLabIdentityProvider
+	var gitlab legacyconfigv1.GitLabIdentityProvider
 
 	_, _, err := serializer.Decode(p.Provider.Raw, nil, &gitlab)
 	if err != nil {

--- a/pkg/transform/oauth/google.go
+++ b/pkg/transform/oauth/google.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/fusor/cpma/pkg/io"
 	"github.com/fusor/cpma/pkg/transform/secrets"
-	configv1 "github.com/openshift/api/legacyconfig/v1"
+	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
@@ -28,7 +28,7 @@ func buildGoogleIP(serializer *json.Serializer, p IdentityProvider) (*IdentityPr
 		err    error
 		idP    = &IdentityProviderGoogle{}
 		secret *secrets.Secret
-		google configv1.GoogleIdentityProvider
+		google legacyconfigv1.GoogleIdentityProvider
 	)
 	_, _, err = serializer.Decode(p.Provider.Raw, nil, &google)
 	if err != nil {
@@ -60,7 +60,7 @@ func buildGoogleIP(serializer *json.Serializer, p IdentityProvider) (*IdentityPr
 }
 
 func validateGoogleProvider(serializer *json.Serializer, p IdentityProvider) error {
-	var google configv1.GoogleIdentityProvider
+	var google legacyconfigv1.GoogleIdentityProvider
 
 	_, _, err := serializer.Decode(p.Provider.Raw, nil, &google)
 	if err != nil {

--- a/pkg/transform/oauth/htpasswd.go
+++ b/pkg/transform/oauth/htpasswd.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 
 	"github.com/fusor/cpma/pkg/transform/secrets"
-	configv1 "github.com/openshift/api/legacyconfig/v1"
+	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
@@ -30,7 +30,7 @@ func buildHTPasswdIP(serializer *json.Serializer, p IdentityProvider) (*Identity
 		err      error
 		idP      = &IdentityProviderHTPasswd{}
 		secret   *secrets.Secret
-		htpasswd configv1.HTPasswdPasswordIdentityProvider
+		htpasswd legacyconfigv1.HTPasswdPasswordIdentityProvider
 	)
 
 	_, _, err = serializer.Decode(p.Provider.Raw, nil, &htpasswd)
@@ -59,7 +59,7 @@ func buildHTPasswdIP(serializer *json.Serializer, p IdentityProvider) (*Identity
 }
 
 func validateHTPasswdProvider(serializer *json.Serializer, p IdentityProvider) error {
-	var htpasswd configv1.HTPasswdPasswordIdentityProvider
+	var htpasswd legacyconfigv1.HTPasswdPasswordIdentityProvider
 
 	_, _, err := serializer.Decode(p.Provider.Raw, nil, &htpasswd)
 	if err != nil {

--- a/pkg/transform/oauth/keystone.go
+++ b/pkg/transform/oauth/keystone.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/fusor/cpma/pkg/transform/configmaps"
 	"github.com/fusor/cpma/pkg/transform/secrets"
-	configv1 "github.com/openshift/api/legacyconfig/v1"
+	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
@@ -32,7 +32,7 @@ func buildKeystoneIP(serializer *json.Serializer, p IdentityProvider) (*Identity
 		certSecret, keySecret *secrets.Secret
 		caConfigmap           *configmaps.ConfigMap
 		err                   error
-		keystone              configv1.KeystonePasswordIdentityProvider
+		keystone              legacyconfigv1.KeystonePasswordIdentityProvider
 	)
 	_, _, err = serializer.Decode(p.Provider.Raw, nil, &keystone)
 	if err != nil {
@@ -78,7 +78,7 @@ func buildKeystoneIP(serializer *json.Serializer, p IdentityProvider) (*Identity
 }
 
 func validateKeystoneProvider(serializer *json.Serializer, p IdentityProvider) error {
-	var keystone configv1.KeystonePasswordIdentityProvider
+	var keystone legacyconfigv1.KeystonePasswordIdentityProvider
 
 	_, _, err := serializer.Decode(p.Provider.Raw, nil, &keystone)
 	if err != nil {

--- a/pkg/transform/oauth/ldap.go
+++ b/pkg/transform/oauth/ldap.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/fusor/cpma/pkg/io"
 	"github.com/fusor/cpma/pkg/transform/configmaps"
-	configv1 "github.com/openshift/api/legacyconfig/v1"
+	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
@@ -38,7 +38,7 @@ func buildLdapIP(serializer *json.Serializer, p IdentityProvider) (*IdentityProv
 		err         error
 		idP         = &IdentityProviderLDAP{}
 		caConfigmap *configmaps.ConfigMap
-		ldap        configv1.LDAPPasswordIdentityProvider
+		ldap        legacyconfigv1.LDAPPasswordIdentityProvider
 	)
 	_, _, err = serializer.Decode(p.Provider.Raw, nil, &ldap)
 	if err != nil {
@@ -77,7 +77,7 @@ func buildLdapIP(serializer *json.Serializer, p IdentityProvider) (*IdentityProv
 }
 
 func validateLDAPProvider(serializer *json.Serializer, p IdentityProvider) error {
-	var ldap configv1.LDAPPasswordIdentityProvider
+	var ldap legacyconfigv1.LDAPPasswordIdentityProvider
 
 	_, _, err := serializer.Decode(p.Provider.Raw, nil, &ldap)
 	if err != nil {

--- a/pkg/transform/oauth/oauth.go
+++ b/pkg/transform/oauth/oauth.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/fusor/cpma/pkg/transform/configmaps"
 	"github.com/fusor/cpma/pkg/transform/secrets"
-	configv1 "github.com/openshift/api/legacyconfig/v1"
+	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	oauthv1 "github.com/openshift/api/oauth/v1"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -15,7 +15,7 @@ import (
 
 func init() {
 	oauthv1.Install(scheme.Scheme)
-	configv1.InstallLegacy(scheme.Scheme)
+	legacyconfigv1.InstallLegacy(scheme.Scheme)
 }
 
 // reference:
@@ -230,7 +230,7 @@ func validateMappingMethod(method string) error {
 	return errors.New("Not valid mapping method")
 }
 
-func validateClientData(clientID string, clientSecret configv1.StringSource) error {
+func validateClientData(clientID string, clientSecret legacyconfigv1.StringSource) error {
 	if clientID == "" {
 		return errors.New("Client ID can't be empty")
 	}

--- a/pkg/transform/oauth/oauth_test.go
+++ b/pkg/transform/oauth/oauth_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/fusor/cpma/pkg/transform/oauth"
-	configv1 "github.com/openshift/api/legacyconfig/v1"
+	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	k8sjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
@@ -20,7 +20,7 @@ func TestTransformMasterConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	serializer := k8sjson.NewYAMLSerializer(k8sjson.DefaultMetaFactory, scheme.Scheme, scheme.Scheme)
-	var masterV3 configv1.MasterConfig
+	var masterV3 legacyconfigv1.MasterConfig
 
 	_, _, err = serializer.Decode(content, nil, &masterV3)
 	require.NoError(t, err)

--- a/pkg/transform/oauth/openid.go
+++ b/pkg/transform/oauth/openid.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/fusor/cpma/pkg/io"
 	"github.com/fusor/cpma/pkg/transform/secrets"
-	configv1 "github.com/openshift/api/legacyconfig/v1"
+	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
@@ -42,7 +42,7 @@ func buildOpenIDIP(serializer *json.Serializer, p IdentityProvider) (*IdentityPr
 		err    error
 		secret *secrets.Secret
 		idP    = &IdentityProviderOpenID{}
-		openID configv1.OpenIDIdentityProvider
+		openID legacyconfigv1.OpenIDIdentityProvider
 	)
 	_, _, err = serializer.Decode(p.Provider.Raw, nil, &openID)
 	if err != nil {
@@ -78,7 +78,7 @@ func buildOpenIDIP(serializer *json.Serializer, p IdentityProvider) (*IdentityPr
 }
 
 func validateOpenIDProvider(serializer *json.Serializer, p IdentityProvider) error {
-	var openID configv1.OpenIDIdentityProvider
+	var openID legacyconfigv1.OpenIDIdentityProvider
 
 	_, _, err := serializer.Decode(p.Provider.Raw, nil, &openID)
 	if err != nil {

--- a/pkg/transform/oauth/requestheader.go
+++ b/pkg/transform/oauth/requestheader.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	"github.com/fusor/cpma/pkg/transform/configmaps"
-	configv1 "github.com/openshift/api/legacyconfig/v1"
+	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
@@ -31,7 +31,7 @@ func buildRequestHeaderIP(serializer *json.Serializer, p IdentityProvider) (*Ide
 		err           error
 		idP           = &IdentityProviderRequestHeader{}
 		caConfigmap   *configmaps.ConfigMap
-		requestHeader configv1.RequestHeaderIdentityProvider
+		requestHeader legacyconfigv1.RequestHeaderIdentityProvider
 	)
 	_, _, err = serializer.Decode(p.Provider.Raw, nil, &requestHeader)
 	if err != nil {
@@ -61,7 +61,7 @@ func buildRequestHeaderIP(serializer *json.Serializer, p IdentityProvider) (*Ide
 }
 
 func validateRequestHeaderProvider(serializer *json.Serializer, p IdentityProvider) error {
-	var requestHeader configv1.RequestHeaderIdentityProvider
+	var requestHeader legacyconfigv1.RequestHeaderIdentityProvider
 
 	_, _, err := serializer.Decode(p.Provider.Raw, nil, &requestHeader)
 	if err != nil {

--- a/pkg/transform/sdn/sdn.go
+++ b/pkg/transform/sdn/sdn.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"net"
 
-	configv1 "github.com/openshift/api/legacyconfig/v1"
+	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	"gopkg.in/yaml.v2"
 )
 
@@ -46,7 +46,7 @@ const (
 )
 
 // Translate is called by Transform to do the majority of the work in converting data
-func Translate(masterConfig configv1.MasterConfig) (NetworkCR, error) {
+func Translate(masterConfig legacyconfigv1.MasterConfig) (NetworkCR, error) {
 	networkConfig := masterConfig.NetworkConfig
 	var networkCR NetworkCR
 
@@ -70,7 +70,7 @@ func Translate(masterConfig configv1.MasterConfig) (NetworkCR, error) {
 }
 
 // TranslateClusterNetworks converts Cluster Networks from OCP3 to OCP4
-func TranslateClusterNetworks(clusterNeworkEntries []configv1.ClusterNetworkEntry) []ClusterNetwork {
+func TranslateClusterNetworks(clusterNeworkEntries []legacyconfigv1.ClusterNetworkEntry) []ClusterNetwork {
 	var translatedClusterNetworks []ClusterNetwork
 
 	for _, networkConfig := range clusterNeworkEntries {
@@ -106,7 +106,7 @@ func SelectNetworkPlugin(pluginName string) (string, error) {
 }
 
 // Validate validate SDN config
-func Validate(masterConfig configv1.MasterConfig) error {
+func Validate(masterConfig legacyconfigv1.MasterConfig) error {
 	networkConfig := masterConfig.NetworkConfig
 
 	if len(networkConfig.ServiceNetworkCIDR) == 0 {

--- a/pkg/transform/sdn/sdn_test.go
+++ b/pkg/transform/sdn/sdn_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/fusor/cpma/pkg/transform/sdn"
 	cpmatest "github.com/fusor/cpma/pkg/utils/test"
-	configv1 "github.com/openshift/api/legacyconfig/v1"
+	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -106,16 +106,16 @@ func TestSelectNetworkPlugin(t *testing.T) {
 func TestTransformClusterNetworks(t *testing.T) {
 	testCases := []struct {
 		name   string
-		input  []configv1.ClusterNetworkEntry
+		input  []legacyconfigv1.ClusterNetworkEntry
 		output []sdn.ClusterNetwork
 	}{
 		{
 			name: "transform cluster networks",
-			input: []configv1.ClusterNetworkEntry{
-				configv1.ClusterNetworkEntry{CIDR: "10.128.0.0/14",
+			input: []legacyconfigv1.ClusterNetworkEntry{
+				legacyconfigv1.ClusterNetworkEntry{CIDR: "10.128.0.0/14",
 					HostSubnetLength: uint32(9),
 				},
-				configv1.ClusterNetworkEntry{CIDR: "10.127.0.0/14",
+				legacyconfigv1.ClusterNetworkEntry{CIDR: "10.127.0.0/14",
 					HostSubnetLength: uint32(9),
 				},
 			},

--- a/pkg/transform/sdn_transform.go
+++ b/pkg/transform/sdn_transform.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fusor/cpma/pkg/env"
 	"github.com/fusor/cpma/pkg/io"
 	"github.com/fusor/cpma/pkg/transform/sdn"
-	configv1 "github.com/openshift/api/legacyconfig/v1"
+	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	"github.com/sirupsen/logrus"
 )
 
@@ -16,7 +16,7 @@ const SDNComponentName = "SDN"
 
 // SDNExtraction is an SDN specific extraction
 type SDNExtraction struct {
-	configv1.MasterConfig
+	legacyconfigv1.MasterConfig
 }
 
 // SDNTransform is an SDN specific transform

--- a/pkg/transform/transform_test.go
+++ b/pkg/transform/transform_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fusor/cpma/pkg/transform/configmaps"
 	"github.com/fusor/cpma/pkg/transform/oauth"
 	"github.com/fusor/cpma/pkg/transform/secrets"
-	configv1 "github.com/openshift/api/legacyconfig/v1"
+	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	k8sjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
@@ -48,7 +48,7 @@ func TestOauthGenYAML(t *testing.T) {
 			require.NoError(t, err)
 
 			serializer := k8sjson.NewYAMLSerializer(k8sjson.DefaultMetaFactory, scheme.Scheme, scheme.Scheme)
-			var masterV3 configv1.MasterConfig
+			var masterV3 legacyconfigv1.MasterConfig
 
 			_, _, err = serializer.Decode(content, nil, &masterV3)
 			require.NoError(t, err)

--- a/pkg/utils/test/load_test_data.go
+++ b/pkg/utils/test/load_test_data.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/fusor/cpma/pkg/transform"
 	"github.com/fusor/cpma/pkg/transform/oauth"
-	configv1 "github.com/openshift/api/legacyconfig/v1"
+	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	k8sjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/client-go/kubernetes/scheme"
 )
@@ -19,7 +19,7 @@ func LoadIPTestData(file string) ([]oauth.IdentityProvider, error) {
 	}
 
 	serializer := k8sjson.NewYAMLSerializer(k8sjson.DefaultMetaFactory, scheme.Scheme, scheme.Scheme)
-	var masterV3 configv1.MasterConfig
+	var masterV3 legacyconfigv1.MasterConfig
 
 	_, _, err = serializer.Decode(content, nil, &masterV3)
 	if err != nil {


### PR DESCRIPTION
The main reason for renaming the package identifier is to avoid future confusion when importing the config/v1.