### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:latest AS builder
+RUN mkdir /app 
+ADD . /app/ 
+WORKDIR /app 
+RUN make
+
+FROM registry.redhat.io/ubi8/ubi
+COPY --from=builder /app/bin/cpma /usr/local/bin/cpma
+WORKDIR /mnt 
+ENTRYPOINT ["cpma"]
+LABEL RUN docker run -it --rm -v \${PWD}:/mnt:z -v \$HOME/.kube:/.kube:z -v \$HOME/.ssh:/.ssh:z -u \${UID} \${IMAGE}


### PR DESCRIPTION
There is a desire to have the utility packaged in a container so that it can be run on CoreOS, Atomic Host, Mac, Windows, or anywhere else docker is available.

This is utilizing a multi-stage build. You will need a sufficiently new docker or alternative to build it properly. The docker package in Fedora/RHEL will not work. moby-engine, docker-ce, podman/buildah, etc. should all work.

Once this is merged I'll set up automated builds for quay.io/ocpmigrate/cpma