### PR TITLE
Use an unauthenticated registry for ubi so Quay builds work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ADD . /app/
 WORKDIR /app 
 RUN make
 
-FROM registry.redhat.io/ubi8/ubi
+FROM registry.access.redhat.com/ubi8/ubi
 COPY --from=builder /app/bin/cpma /usr/local/bin/cpma
 WORKDIR /mnt 
 ENTRYPOINT ["cpma"]


### PR DESCRIPTION
I thought registry.access.redhat.com was depricated and didn't realize I was authenticated when I tested the build so this needs to be changed to fixed in order for Quay builds to be able to pull the base image to work.

https://bugzilla.redhat.com/show_bug.cgi?id=1719994#c3
https://bugzilla.redhat.com/show_bug.cgi?id=1719994#c4

Basically registry.access.redhat.com isn't going away any time soon specifically because of UBI.