### PR TITLE
Image unsupported param

### DIFF
--- a/pkg/transform/image/image.go
+++ b/pkg/transform/image/image.go
@@ -17,10 +17,6 @@ func Translate(imageCR *configv1.Image, imagePolicyConfig legacyconfigv1.ImagePo
 		}
 	}
 
-	if imagePolicyConfig.AdditionalTrustedCA != "" {
-		imageCR.Spec.AdditionalTrustedCA.Name = imagePolicyConfig.AdditionalTrustedCA
-	}
-
 	if imagePolicyConfig.ExternalRegistryHostname != "" {
 		imageCR.Spec.ExternalRegistryHostnames = append(imageCR.Spec.ExternalRegistryHostnames, imagePolicyConfig.ExternalRegistryHostname)
 	}

--- a/pkg/transform/image_transform.go
+++ b/pkg/transform/image_transform.go
@@ -144,8 +144,9 @@ func (e ImageExtraction) buildReportOutput() (Output, error) {
 		Report{
 			Name:       "AdditionalTrustedCA",
 			Kind:       "MasterConfig.ImagePolicyConfig",
-			Supported:  true,
-			Confidence: HighConfidence,
+			Supported:  false,
+			Confidence: NoConfidence,
+			Comment:    "Each registry must provide its own self-signed CA",
 		})
 
 	reportOutput.Reports = append(reportOutput.Reports,

--- a/pkg/transform/image_transform.go
+++ b/pkg/transform/image_transform.go
@@ -157,6 +157,51 @@ func (e ImageExtraction) buildReportOutput() (Output, error) {
 			Confidence: HighConfidence,
 		})
 
+	reportOutput.Reports = append(reportOutput.Reports,
+		Report{
+			Name:       "InternalRegistryHostname",
+			Kind:       "MasterConfig.ImagePolicyConfig",
+			Supported:  false,
+			Confidence: NoConfidence,
+			Comment:    "Set by OCP4 image registry operator",
+		})
+
+	reportOutput.Reports = append(reportOutput.Reports,
+		Report{
+			Name:       "DisableScheduledImport",
+			Kind:       "MasterConfig.ImagePolicyConfig",
+			Supported:  false,
+			Confidence: NoConfidence,
+			Comment:    "Not supported by OCP4",
+		})
+
+	reportOutput.Reports = append(reportOutput.Reports,
+		Report{
+			Name:       "MaxImagesBulkImportedPerRepository",
+			Kind:       "MasterConfig.ImagePolicyConfig",
+			Supported:  false,
+			Confidence: NoConfidence,
+			Comment:    "Not supported by OCP4",
+		})
+
+	reportOutput.Reports = append(reportOutput.Reports,
+		Report{
+			Name:       "MaxScheduledImageImportsPerMinute",
+			Kind:       "MasterConfig.ImagePolicyConfig",
+			Supported:  false,
+			Confidence: NoConfidence,
+			Comment:    "Not supported by OCP4",
+		})
+
+	reportOutput.Reports = append(reportOutput.Reports,
+		Report{
+			Name:       "ScheduledImageImportMinimumIntervalSeconds",
+			Kind:       "MasterConfig.ImagePolicyConfig",
+			Supported:  false,
+			Confidence: NoConfidence,
+			Comment:    "Not supported by OCP4",
+		})
+
 	return reportOutput, nil
 }
 

--- a/pkg/transform/testdata/expected-report-image.json
+++ b/pkg/transform/testdata/expected-report-image.json
@@ -1,1 +1,40 @@
-{"component":"Image","reports":[{"name":"Blocked","kind":"Registries","supported":true,"confidence":2,"comment":""},{"name":"Insecure","kind":"Registries","supported":true,"confidence":2,"comment":""},{"name":"Search","kind":"Registries","supported":false,"confidence":0,"comment":"Search registries can not be configured in OCP 4: search.test.com"},{"name":"AllowedRegistriesForImport","kind":"MasterConfig.ImagePolicyConfig","supported":true,"confidence":2,"comment":""},{"name":"AdditionalTrustedCA","kind":"MasterConfig.ImagePolicyConfig","supported":true,"confidence":2,"comment":""},{"name":"ExternalRegistryHostname","kind":"MasterConfig.ImagePolicyConfig","supported":true,"confidence":2,"comment":""}]}
+{
+  "component": "Image",
+  "reports": [{
+    "name": "Blocked",
+    "kind": "Registries",
+    "supported": true,
+    "confidence": 2,
+    "comment": ""
+  }, {
+    "name": "Insecure",
+    "kind": "Registries",
+    "supported": true,
+    "confidence": 2,
+    "comment": ""
+  }, {
+    "name": "Search",
+    "kind": "Registries",
+    "supported": false,
+    "confidence": 0,
+    "comment": "Search registries can not be configured in OCP 4: search.test.com"
+  }, {
+    "name": "AllowedRegistriesForImport",
+    "kind": "MasterConfig.ImagePolicyConfig",
+    "supported": true,
+    "confidence": 2,
+    "comment": ""
+  }, {
+    "name": "AdditionalTrustedCA",
+    "kind": "MasterConfig.ImagePolicyConfig",
+    "supported": false,
+    "confidence": 0,
+    "comment": "Each registry must provide its own self-signed CA"
+  }, {
+    "name": "ExternalRegistryHostname",
+    "kind": "MasterConfig.ImagePolicyConfig",
+    "supported": true,
+    "confidence": 2,
+    "comment": ""
+  }]
+}

--- a/pkg/transform/testdata/expected-report-image.json
+++ b/pkg/transform/testdata/expected-report-image.json
@@ -36,5 +36,35 @@
     "supported": true,
     "confidence": 2,
     "comment": ""
+  }, {
+    "name": "InternalRegistryHostname",
+    "kind": "MasterConfig.ImagePolicyConfig",
+    "supported": false,
+    "confidence": 0,
+    "comment": "Set by OCP4 image registry operator"
+  }, {
+    "name": "DisableScheduledImport",
+    "kind": "MasterConfig.ImagePolicyConfig",
+    "supported": false,
+    "confidence": 0,
+    "comment": "Not supported by OCP4"
+  }, {
+    "name": "MaxImagesBulkImportedPerRepository",
+    "kind": "MasterConfig.ImagePolicyConfig",
+    "supported": false,
+    "confidence": 0,
+    "comment": "Not supported by OCP4"
+  }, {
+    "name": "MaxScheduledImageImportsPerMinute",
+    "kind": "MasterConfig.ImagePolicyConfig",
+    "supported": false,
+    "confidence": 0,
+    "comment": "Not supported by OCP4"
+  }, {
+    "name": "ScheduledImageImportMinimumIntervalSeconds",
+    "kind": "MasterConfig.ImagePolicyConfig",
+    "supported": false,
+    "confidence": 0,
+    "comment": "Not supported by OCP4"
   }]
 }


### PR DESCRIPTION
The following parameters are not supported in OCP4:
- AdditionalTrustedCA 
- MaxImagesBulkImportedPerRepository
- MaxScheduledImageImportsPerMinute
- ScheduledImageImportMinimumIntervalSeconds

Also beautified `pkg/transform/testdata/expected-report-image.json`