### PR TITLE
Use configv1 structures for oauth

### DIFF
--- a/pkg/transform/oauth/basicauth.go
+++ b/pkg/transform/oauth/basicauth.go
@@ -28,6 +28,7 @@ func buildBasicAuthIP(serializer *json.Serializer, p IdentityProvider) (*configv
 	idP.Type = "BasicAuth"
 	idP.Name = p.Name
 	idP.MappingMethod = configv1.MappingMethodType(p.MappingMethod)
+	idP.BasicAuth = &configv1.BasicAuthIdentityProvider{}
 	idP.BasicAuth.URL = basicAuth.URL
 
 	if basicAuth.CA != "" {

--- a/pkg/transform/oauth/basicauth.go
+++ b/pkg/transform/oauth/basicauth.go
@@ -3,6 +3,8 @@ package oauth
 import (
 	"encoding/base64"
 
+	configv1 "github.com/openshift/api/config/v1"
+
 	"github.com/fusor/cpma/pkg/transform/configmaps"
 	"github.com/fusor/cpma/pkg/transform/secrets"
 	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
@@ -10,25 +12,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
-// IdentityProviderBasicAuth is a basic auth specific identity provider
-type IdentityProviderBasicAuth struct {
-	identityProviderCommon `json:",inline"`
-	BasicAuth              BasicAuth `json:"basicAuth"`
-}
-
-// BasicAuth provider specific data
-// BasicAuth provider specific data
-type BasicAuth struct {
-	URL           string         `json:"url"`
-	CA            *CA            `json:"ca,omitempty"`
-	TLSClientCert *TLSClientCert `json:"tlsClientCert,omitempty"`
-	TLSClientKey  *TLSClientKey  `json:"tlsClientKey,omitempty"`
-}
-
-func buildBasicAuthIP(serializer *json.Serializer, p IdentityProvider) (*IdentityProviderBasicAuth, *secrets.Secret, *secrets.Secret, *configmaps.ConfigMap, error) {
+func buildBasicAuthIP(serializer *json.Serializer, p IdentityProvider) (*configv1.IdentityProvider, *secrets.Secret, *secrets.Secret, *configmaps.ConfigMap, error) {
 	var (
 		err                   error
-		idP                   = &IdentityProviderBasicAuth{}
+		idP                   = &configv1.IdentityProvider{}
 		certSecret, keySecret *secrets.Secret
 		caConfigmap           *configmaps.ConfigMap
 		basicAuth             legacyconfigv1.BasicAuthPasswordIdentityProvider
@@ -40,19 +27,17 @@ func buildBasicAuthIP(serializer *json.Serializer, p IdentityProvider) (*Identit
 
 	idP.Type = "BasicAuth"
 	idP.Name = p.Name
-	idP.Challenge = p.UseAsChallenger
-	idP.Login = p.UseAsLogin
-	idP.MappingMethod = p.MappingMethod
+	idP.MappingMethod = configv1.MappingMethodType(p.MappingMethod)
 	idP.BasicAuth.URL = basicAuth.URL
 
 	if basicAuth.CA != "" {
 		caConfigmap = configmaps.GenConfigMap("basicauth-configmap", OAuthNamespace, p.CAData)
-		idP.BasicAuth.CA = &CA{Name: caConfigmap.Metadata.Name}
+		idP.BasicAuth.CA = configv1.ConfigMapNameReference{Name: caConfigmap.Metadata.Name}
 	}
 
 	if basicAuth.CertFile != "" {
 		certSecretName := p.Name + "-client-cert-secret"
-		idP.BasicAuth.TLSClientCert = &TLSClientCert{Name: certSecretName}
+		idP.BasicAuth.TLSClientCert.Name = certSecretName
 
 		encoded := base64.StdEncoding.EncodeToString(p.CrtData)
 		if certSecret, err = secrets.GenSecret(certSecretName, encoded, OAuthNamespace, secrets.BasicAuthSecretType); err != nil {
@@ -60,7 +45,7 @@ func buildBasicAuthIP(serializer *json.Serializer, p IdentityProvider) (*Identit
 		}
 
 		keySecretName := p.Name + "-client-key-secret"
-		idP.BasicAuth.TLSClientKey = &TLSClientKey{Name: keySecretName}
+		idP.BasicAuth.TLSClientKey.Name = keySecretName
 
 		encoded = base64.StdEncoding.EncodeToString(p.KeyData)
 		if keySecret, err = secrets.GenSecret(keySecretName, encoded, OAuthNamespace, secrets.BasicAuthSecretType); err != nil {

--- a/pkg/transform/oauth/basicauth_test.go
+++ b/pkg/transform/oauth/basicauth_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/fusor/cpma/pkg/transform/oauth"
 	cpmatest "github.com/fusor/cpma/pkg/utils/test"
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,28 +15,27 @@ func TestTransformMasterConfigBasicAuth(t *testing.T) {
 	identityProviders, err := cpmatest.LoadIPTestData("testdata/basicauth/master_config.yaml")
 	require.NoError(t, err)
 
-	var expectedCrd oauth.CRD
+	var expectedCrd configv1.OAuth
 	expectedCrd.APIVersion = "config.openshift.io/v1"
 	expectedCrd.Kind = "OAuth"
-	expectedCrd.Metadata.Name = "cluster"
-	expectedCrd.Metadata.NameSpace = oauth.OAuthNamespace
+	expectedCrd.Name = "cluster"
+	expectedCrd.Namespace = oauth.OAuthNamespace
 
-	var basicAuthIDP = &oauth.IdentityProviderBasicAuth{}
+	var basicAuthIDP = &configv1.IdentityProvider{}
 	basicAuthIDP.Type = "BasicAuth"
-	basicAuthIDP.Challenge = true
-	basicAuthIDP.Login = true
 	basicAuthIDP.Name = "my_remote_basic_auth_provider"
 	basicAuthIDP.MappingMethod = "claim"
+	basicAuthIDP.BasicAuth = &configv1.BasicAuthIdentityProvider{}
 	basicAuthIDP.BasicAuth.URL = "https://www.example.com/"
-	basicAuthIDP.BasicAuth.TLSClientCert = &oauth.TLSClientCert{Name: "my_remote_basic_auth_provider-client-cert-secret"}
-	basicAuthIDP.BasicAuth.TLSClientKey = &oauth.TLSClientKey{Name: "my_remote_basic_auth_provider-client-key-secret"}
-	basicAuthIDP.BasicAuth.CA = &oauth.CA{Name: "basicauth-configmap"}
+	basicAuthIDP.BasicAuth.TLSClientCert.Name = "my_remote_basic_auth_provider-client-cert-secret"
+	basicAuthIDP.BasicAuth.TLSClientKey.Name = "my_remote_basic_auth_provider-client-key-secret"
+	basicAuthIDP.BasicAuth.CA = configv1.ConfigMapNameReference{Name: "basicauth-configmap"}
 
-	expectedCrd.Spec.IdentityProviders = append(expectedCrd.Spec.IdentityProviders, basicAuthIDP)
+	expectedCrd.Spec.IdentityProviders = append(expectedCrd.Spec.IdentityProviders, *basicAuthIDP)
 
 	testCases := []struct {
 		name        string
-		expectedCrd *oauth.CRD
+		expectedCrd *configv1.OAuth
 	}{
 		{
 			name:        "build basic auth provider",

--- a/pkg/transform/oauth/github_test.go
+++ b/pkg/transform/oauth/github_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/fusor/cpma/pkg/transform/oauth"
 	cpmatest "github.com/fusor/cpma/pkg/utils/test"
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -14,29 +15,28 @@ func TestTransformMasterConfigGithub(t *testing.T) {
 	identityProviders, err := cpmatest.LoadIPTestData("testdata/github/master_config.yaml")
 	require.NoError(t, err)
 
-	var expectedCrd oauth.CRD
+	var expectedCrd configv1.OAuth
 	expectedCrd.APIVersion = "config.openshift.io/v1"
 	expectedCrd.Kind = "OAuth"
-	expectedCrd.Metadata.Name = "cluster"
-	expectedCrd.Metadata.NameSpace = oauth.OAuthNamespace
+	expectedCrd.Name = "cluster"
+	expectedCrd.Namespace = oauth.OAuthNamespace
 
-	var githubIDP = &oauth.IdentityProviderGitHub{}
+	var githubIDP = &configv1.IdentityProvider{}
 	githubIDP.Type = "GitHub"
-	githubIDP.Challenge = false
-	githubIDP.Login = true
 	githubIDP.MappingMethod = "claim"
 	githubIDP.Name = "github123456789"
-	githubIDP.GitHub.HostName = "test.example.com"
-	githubIDP.GitHub.CA = &oauth.CA{Name: "github-configmap"}
+	githubIDP.GitHub = &configv1.GitHubIdentityProvider{}
+	githubIDP.GitHub.Hostname = "test.example.com"
+	githubIDP.GitHub.CA = configv1.ConfigMapNameReference{Name: "github-configmap"}
 	githubIDP.GitHub.ClientID = "2d85ea3f45d6777bffd7"
 	githubIDP.GitHub.Organizations = []string{"myorganization1", "myorganization2"}
 	githubIDP.GitHub.Teams = []string{"myorganization1/team-a", "myorganization2/team-b"}
 	githubIDP.GitHub.ClientSecret.Name = "github123456789-secret"
-	expectedCrd.Spec.IdentityProviders = append(expectedCrd.Spec.IdentityProviders, githubIDP)
+	expectedCrd.Spec.IdentityProviders = append(expectedCrd.Spec.IdentityProviders, *githubIDP)
 
 	testCases := []struct {
 		name        string
-		expectedCrd *oauth.CRD
+		expectedCrd *configv1.OAuth
 	}{
 		{
 			name:        "build github provider",

--- a/pkg/transform/oauth/gitlab.go
+++ b/pkg/transform/oauth/gitlab.go
@@ -28,6 +28,7 @@ func buildGitLabIP(serializer *json.Serializer, p IdentityProvider) (*configv1.I
 	idP.Type = "GitLab"
 	idP.Name = p.Name
 	idP.MappingMethod = configv1.MappingMethodType(p.MappingMethod)
+	idP.GitLab = &configv1.GitLabIdentityProvider{}
 	idP.GitLab.URL = gitlab.URL
 	idP.GitLab.ClientID = gitlab.ClientID
 

--- a/pkg/transform/oauth/gitlab_test.go
+++ b/pkg/transform/oauth/gitlab_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/fusor/cpma/pkg/transform/oauth"
 	cpmatest "github.com/fusor/cpma/pkg/utils/test"
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -14,27 +15,26 @@ func TestTransformMasterConfigGitlab(t *testing.T) {
 	identityProviders, err := cpmatest.LoadIPTestData("testdata/gitlab/master_config.yaml")
 	require.NoError(t, err)
 
-	var expectedCrd oauth.CRD
+	var expectedCrd configv1.OAuth
 	expectedCrd.APIVersion = "config.openshift.io/v1"
 	expectedCrd.Kind = "OAuth"
-	expectedCrd.Metadata.Name = "cluster"
-	expectedCrd.Metadata.NameSpace = oauth.OAuthNamespace
+	expectedCrd.Name = "cluster"
+	expectedCrd.Namespace = oauth.OAuthNamespace
 
-	var gitlabIDP = &oauth.IdentityProviderGitLab{}
+	var gitlabIDP = &configv1.IdentityProvider{}
 	gitlabIDP.Type = "GitLab"
-	gitlabIDP.Challenge = true
-	gitlabIDP.Login = true
 	gitlabIDP.MappingMethod = "claim"
 	gitlabIDP.Name = "gitlab123456789"
+	gitlabIDP.GitLab = &configv1.GitLabIdentityProvider{}
 	gitlabIDP.GitLab.URL = "https://gitlab.com/"
-	gitlabIDP.GitLab.CA = &oauth.CA{Name: "gitlab-configmap"}
+	gitlabIDP.GitLab.CA = configv1.ConfigMapNameReference{Name: "gitlab-configmap"}
 	gitlabIDP.GitLab.ClientID = "fake-id"
 	gitlabIDP.GitLab.ClientSecret.Name = "gitlab123456789-secret"
-	expectedCrd.Spec.IdentityProviders = append(expectedCrd.Spec.IdentityProviders, gitlabIDP)
+	expectedCrd.Spec.IdentityProviders = append(expectedCrd.Spec.IdentityProviders, *gitlabIDP)
 
 	testCases := []struct {
 		name        string
-		expectedCrd *oauth.CRD
+		expectedCrd *configv1.OAuth
 	}{
 		{
 			name:        "build gitlab provider",

--- a/pkg/transform/oauth/google.go
+++ b/pkg/transform/oauth/google.go
@@ -26,6 +26,7 @@ func buildGoogleIP(serializer *json.Serializer, p IdentityProvider) (*configv1.I
 	idP.Type = "Google"
 	idP.Name = p.Name
 	idP.MappingMethod = configv1.MappingMethodType(p.MappingMethod)
+	idP.Google = &configv1.GoogleIdentityProvider{}
 	idP.Google.ClientID = google.ClientID
 	idP.Google.HostedDomain = google.HostedDomain
 

--- a/pkg/transform/oauth/google.go
+++ b/pkg/transform/oauth/google.go
@@ -5,28 +5,16 @@ import (
 
 	"github.com/fusor/cpma/pkg/io"
 	"github.com/fusor/cpma/pkg/transform/secrets"
+	configv1 "github.com/openshift/api/config/v1"
 	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
-//IdentityProviderGoogle is a Google specific identity provider
-type IdentityProviderGoogle struct {
-	identityProviderCommon `json:",inline"`
-	Google                 Google `json:"google"`
-}
-
-// Google provider specific data
-type Google struct {
-	ClientID     string       `json:"clientID"`
-	ClientSecret ClientSecret `json:"clientSecret"`
-	HostedDomain string       `json:"hostedDomain,omitempty"`
-}
-
-func buildGoogleIP(serializer *json.Serializer, p IdentityProvider) (*IdentityProviderGoogle, *secrets.Secret, error) {
+func buildGoogleIP(serializer *json.Serializer, p IdentityProvider) (*configv1.IdentityProvider, *secrets.Secret, error) {
 	var (
 		err    error
-		idP    = &IdentityProviderGoogle{}
+		idP    = &configv1.IdentityProvider{}
 		secret *secrets.Secret
 		google legacyconfigv1.GoogleIdentityProvider
 	)
@@ -37,9 +25,7 @@ func buildGoogleIP(serializer *json.Serializer, p IdentityProvider) (*IdentityPr
 
 	idP.Type = "Google"
 	idP.Name = p.Name
-	idP.Challenge = p.UseAsChallenger
-	idP.Login = p.UseAsLogin
-	idP.MappingMethod = p.MappingMethod
+	idP.MappingMethod = configv1.MappingMethodType(p.MappingMethod)
 	idP.Google.ClientID = google.ClientID
 	idP.Google.HostedDomain = google.HostedDomain
 

--- a/pkg/transform/oauth/google_test.go
+++ b/pkg/transform/oauth/google_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/fusor/cpma/pkg/transform/oauth"
 	cpmatest "github.com/fusor/cpma/pkg/utils/test"
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -14,26 +15,25 @@ func TestTransformMasterConfigGoogle(t *testing.T) {
 	identityProviders, err := cpmatest.LoadIPTestData("testdata/google/master_config.yaml")
 	require.NoError(t, err)
 
-	var expectedCrd oauth.CRD
+	var expectedCrd configv1.OAuth
 	expectedCrd.APIVersion = "config.openshift.io/v1"
 	expectedCrd.Kind = "OAuth"
-	expectedCrd.Metadata.Name = "cluster"
-	expectedCrd.Metadata.NameSpace = oauth.OAuthNamespace
+	expectedCrd.Name = "cluster"
+	expectedCrd.Namespace = oauth.OAuthNamespace
 
-	var googleIDP = &oauth.IdentityProviderGoogle{}
+	var googleIDP = &configv1.IdentityProvider{}
 	googleIDP.Type = "Google"
-	googleIDP.Challenge = false
-	googleIDP.Login = true
 	googleIDP.MappingMethod = "claim"
 	googleIDP.Name = "google123456789123456789"
+	googleIDP.Google = &configv1.GoogleIdentityProvider{}
 	googleIDP.Google.ClientID = "82342890327-tf5lqn4eikdf4cb4edfm85jiqotvurpq.apps.googleusercontent.com"
 	googleIDP.Google.ClientSecret.Name = "google123456789123456789-secret"
 	googleIDP.Google.HostedDomain = "test.example.com"
-	expectedCrd.Spec.IdentityProviders = append(expectedCrd.Spec.IdentityProviders, googleIDP)
+	expectedCrd.Spec.IdentityProviders = append(expectedCrd.Spec.IdentityProviders, *googleIDP)
 
 	testCases := []struct {
 		name        string
-		expectedCrd *oauth.CRD
+		expectedCrd *configv1.OAuth
 	}{
 		{
 			name:        "build google provider",

--- a/pkg/transform/oauth/htpasswd_test.go
+++ b/pkg/transform/oauth/htpasswd_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/fusor/cpma/pkg/transform/oauth"
 	cpmatest "github.com/fusor/cpma/pkg/utils/test"
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -14,24 +15,23 @@ func TestTransformMasterConfigHtpasswd(t *testing.T) {
 	identityProviders, err := cpmatest.LoadIPTestData("testdata/htpasswd/master_config.yaml")
 	require.NoError(t, err)
 
-	var expectedCrd oauth.CRD
+	var expectedCrd configv1.OAuth
 	expectedCrd.APIVersion = "config.openshift.io/v1"
 	expectedCrd.Kind = "OAuth"
-	expectedCrd.Metadata.Name = "cluster"
-	expectedCrd.Metadata.NameSpace = oauth.OAuthNamespace
+	expectedCrd.Name = "cluster"
+	expectedCrd.Namespace = oauth.OAuthNamespace
 
-	var htpasswdIDP = &oauth.IdentityProviderHTPasswd{}
+	var htpasswdIDP = &configv1.IdentityProvider{}
 	htpasswdIDP.Name = "htpasswd_auth"
-	htpasswdIDP.Type = "HTPasswd"
-	htpasswdIDP.Challenge = true
-	htpasswdIDP.Login = true
 	htpasswdIDP.MappingMethod = "claim"
+	htpasswdIDP.Type = "HTPasswd"
+	htpasswdIDP.HTPasswd = &configv1.HTPasswdIdentityProvider{}
 	htpasswdIDP.HTPasswd.FileData.Name = "htpasswd_auth-secret"
-	expectedCrd.Spec.IdentityProviders = append(expectedCrd.Spec.IdentityProviders, htpasswdIDP)
+	expectedCrd.Spec.IdentityProviders = append(expectedCrd.Spec.IdentityProviders, *htpasswdIDP)
 
 	testCases := []struct {
 		name        string
-		expectedCrd *oauth.CRD
+		expectedCrd *configv1.OAuth
 	}{
 		{
 			name:        "build htpasswd provider",

--- a/pkg/transform/oauth/keystone.go
+++ b/pkg/transform/oauth/keystone.go
@@ -29,6 +29,7 @@ func buildKeystoneIP(serializer *json.Serializer, p IdentityProvider) (*configv1
 	idP.Type = "Keystone"
 	idP.Name = p.Name
 	idP.MappingMethod = configv1.MappingMethodType(p.MappingMethod)
+	idP.Keystone = &configv1.KeystoneIdentityProvider{}
 	idP.Keystone.DomainName = keystone.DomainName
 	idP.Keystone.URL = keystone.URL
 

--- a/pkg/transform/oauth/keystone.go
+++ b/pkg/transform/oauth/keystone.go
@@ -5,30 +5,17 @@ import (
 
 	"github.com/fusor/cpma/pkg/transform/configmaps"
 	"github.com/fusor/cpma/pkg/transform/secrets"
+	configv1 "github.com/openshift/api/config/v1"
 	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
-// IdentityProviderKeystone is a Keystone specific identity provider
-type IdentityProviderKeystone struct {
-	identityProviderCommon `json:",inline"`
-	Keystone               Keystone `json:"keystone"`
-}
-
-// Keystone specific Provider data
-type Keystone struct {
-	DomainName    string         `json:"domainName"`
-	URL           string         `json:"url"`
-	CA            *CA            `json:"ca,omitempty"`
-	TLSClientCert *TLSClientCert `json:"tlsClientCert,omitempty"`
-	TLSClientKey  *TLSClientKey  `json:"tlsClientKey,omitempty"`
-}
-
-func buildKeystoneIP(serializer *json.Serializer, p IdentityProvider) (*IdentityProviderKeystone, *secrets.Secret, *secrets.Secret, *configmaps.ConfigMap, error) {
+func buildKeystoneIP(serializer *json.Serializer, p IdentityProvider) (*configv1.IdentityProvider, *secrets.Secret, *secrets.Secret, *configmaps.ConfigMap, error) {
 	var (
-		idP                   = &IdentityProviderKeystone{}
+		idP = &configv1.IdentityProvider{}
+
 		certSecret, keySecret *secrets.Secret
 		caConfigmap           *configmaps.ConfigMap
 		err                   error
@@ -41,15 +28,13 @@ func buildKeystoneIP(serializer *json.Serializer, p IdentityProvider) (*Identity
 
 	idP.Type = "Keystone"
 	idP.Name = p.Name
-	idP.Challenge = p.UseAsChallenger
-	idP.Login = p.UseAsLogin
-	idP.MappingMethod = p.MappingMethod
+	idP.MappingMethod = configv1.MappingMethodType(p.MappingMethod)
 	idP.Keystone.DomainName = keystone.DomainName
 	idP.Keystone.URL = keystone.URL
 
 	if keystone.CA != "" {
 		caConfigmap = configmaps.GenConfigMap("keystone-configmap", OAuthNamespace, p.CAData)
-		idP.Keystone.CA = &CA{Name: caConfigmap.Metadata.Name}
+		idP.Keystone.CA = configv1.ConfigMapNameReference{Name: caConfigmap.Metadata.Name}
 	}
 
 	if keystone.UseKeystoneIdentity {
@@ -58,14 +43,14 @@ func buildKeystoneIP(serializer *json.Serializer, p IdentityProvider) (*Identity
 
 	if keystone.CertFile != "" {
 		certSecretName := p.Name + "-client-cert-secret"
-		idP.Keystone.TLSClientCert = &TLSClientCert{Name: certSecretName}
+		idP.Keystone.TLSClientCert.Name = certSecretName
 		encoded := base64.StdEncoding.EncodeToString(p.CrtData)
 		if certSecret, err = secrets.GenSecret(certSecretName, encoded, OAuthNamespace, secrets.KeystoneSecretType); err != nil {
 			return nil, nil, nil, nil, errors.Wrap(err, "Failed to generate cert secret for keystone, see error")
 		}
 
 		keySecretName := p.Name + "-client-key-secret"
-		idP.Keystone.TLSClientKey = &TLSClientKey{Name: keySecretName}
+		idP.Keystone.TLSClientKey.Name = keySecretName
 		encoded = base64.StdEncoding.EncodeToString(p.KeyData)
 		if keySecret, err = secrets.GenSecret(keySecretName, encoded, OAuthNamespace, secrets.KeystoneSecretType); err != nil {
 			return nil, nil, nil, nil, errors.Wrap(err, "Failed to generate key secret for keystone, see error")

--- a/pkg/transform/oauth/ldap.go
+++ b/pkg/transform/oauth/ldap.go
@@ -3,39 +3,16 @@ package oauth
 import (
 	"github.com/fusor/cpma/pkg/io"
 	"github.com/fusor/cpma/pkg/transform/configmaps"
+	configv1 "github.com/openshift/api/config/v1"
 	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
-// IdentityProviderLDAP is a LDAP specific identity provider
-type IdentityProviderLDAP struct {
-	identityProviderCommon `json:",inline"`
-	LDAP                   LDAP `json:"ldap"`
-}
-
-// LDAP provider specific data
-type LDAP struct {
-	Attributes   LDAPAttributes `json:"attributes"`
-	BindDN       string         `json:"bindDN,omitempty"`
-	BindPassword string         `json:"bindPassword,omitempty"`
-	CA           *CA            `json:"ca,omitempty"`
-	Insecure     bool           `json:"insecure"`
-	URL          string         `json:"url"`
-}
-
-// LDAPAttributes for an LDAP provider
-type LDAPAttributes struct {
-	ID                []string `json:"id"`
-	Email             []string `json:"email"`
-	Name              []string `json:"name"`
-	PreferredUsername []string `json:"preferredUsername"`
-}
-
-func buildLdapIP(serializer *json.Serializer, p IdentityProvider) (*IdentityProviderLDAP, *configmaps.ConfigMap, error) {
+func buildLdapIP(serializer *json.Serializer, p IdentityProvider) (*configv1.IdentityProvider, *configmaps.ConfigMap, error) {
 	var (
 		err         error
-		idP         = &IdentityProviderLDAP{}
+		idP         = &configv1.IdentityProvider{}
 		caConfigmap *configmaps.ConfigMap
 		ldap        legacyconfigv1.LDAPPasswordIdentityProvider
 	)
@@ -46,9 +23,7 @@ func buildLdapIP(serializer *json.Serializer, p IdentityProvider) (*IdentityProv
 
 	idP.Type = "LDAP"
 	idP.Name = p.Name
-	idP.Challenge = p.UseAsChallenger
-	idP.Login = p.UseAsLogin
-	idP.MappingMethod = p.MappingMethod
+	idP.MappingMethod = configv1.MappingMethodType(p.MappingMethod)
 	idP.LDAP.Attributes.ID = ldap.Attributes.ID
 	idP.LDAP.Attributes.Email = ldap.Attributes.Email
 	idP.LDAP.Attributes.Name = ldap.Attributes.Name
@@ -61,12 +36,12 @@ func buildLdapIP(serializer *json.Serializer, p IdentityProvider) (*IdentityProv
 			return nil, nil, errors.Wrap(err, "Failed to fetch bind password for ldap")
 		}
 
-		idP.LDAP.BindPassword = bindPassword
+		idP.LDAP.BindPassword.Name = bindPassword
 	}
 
 	if ldap.CA != "" {
 		caConfigmap = configmaps.GenConfigMap("ldap-configmap", OAuthNamespace, p.CAData)
-		idP.LDAP.CA = &CA{Name: caConfigmap.Metadata.Name}
+		idP.LDAP.CA = configv1.ConfigMapNameReference{Name: caConfigmap.Metadata.Name}
 	}
 
 	idP.LDAP.Insecure = ldap.Insecure

--- a/pkg/transform/oauth/ldap.go
+++ b/pkg/transform/oauth/ldap.go
@@ -24,6 +24,7 @@ func buildLdapIP(serializer *json.Serializer, p IdentityProvider) (*configv1.Ide
 	idP.Type = "LDAP"
 	idP.Name = p.Name
 	idP.MappingMethod = configv1.MappingMethodType(p.MappingMethod)
+	idP.LDAP = &configv1.LDAPIdentityProvider{}
 	idP.LDAP.Attributes.ID = ldap.Attributes.ID
 	idP.LDAP.Attributes.Email = ldap.Attributes.Email
 	idP.LDAP.Attributes.Name = ldap.Attributes.Name

--- a/pkg/transform/oauth/ldap_test.go
+++ b/pkg/transform/oauth/ldap_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/fusor/cpma/pkg/transform/oauth"
 	cpmatest "github.com/fusor/cpma/pkg/utils/test"
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -14,33 +15,32 @@ func TestTransformMasterConfigLDAP(t *testing.T) {
 	identityProviders, err := cpmatest.LoadIPTestData("testdata/ldap/master_config.yaml")
 	require.NoError(t, err)
 
-	var expectedCrd oauth.CRD
+	var expectedCrd configv1.OAuth
 	expectedCrd.APIVersion = "config.openshift.io/v1"
 	expectedCrd.Kind = "OAuth"
-	expectedCrd.Metadata.Name = "cluster"
-	expectedCrd.Metadata.NameSpace = oauth.OAuthNamespace
+	expectedCrd.Name = "cluster"
+	expectedCrd.Namespace = oauth.OAuthNamespace
 
-	var ldapIDP = &oauth.IdentityProviderLDAP{}
+	var ldapIDP = &configv1.IdentityProvider{}
 	ldapIDP.Name = "my_ldap_provider"
 	ldapIDP.Type = "LDAP"
-	ldapIDP.Challenge = true
-	ldapIDP.Login = true
 	ldapIDP.MappingMethod = "claim"
+	ldapIDP.LDAP = &configv1.LDAPIdentityProvider{}
 	ldapIDP.LDAP.Attributes.ID = []string{"dn"}
 	ldapIDP.LDAP.Attributes.Email = []string{"mail"}
 	ldapIDP.LDAP.Attributes.Name = []string{"cn"}
 	ldapIDP.LDAP.Attributes.PreferredUsername = []string{"uid"}
 	ldapIDP.LDAP.BindDN = "123"
-	ldapIDP.LDAP.BindPassword = "321"
-	ldapIDP.LDAP.CA = &oauth.CA{Name: "ldap-configmap"}
+	ldapIDP.LDAP.BindPassword.Name = "321"
+	ldapIDP.LDAP.CA = configv1.ConfigMapNameReference{Name: "ldap-configmap"}
 	ldapIDP.LDAP.Insecure = false
 	ldapIDP.LDAP.URL = "ldap://ldap.example.com/ou=users,dc=acme,dc=com?uid"
 
-	expectedCrd.Spec.IdentityProviders = append(expectedCrd.Spec.IdentityProviders, ldapIDP)
+	expectedCrd.Spec.IdentityProviders = append(expectedCrd.Spec.IdentityProviders, *ldapIDP)
 
 	testCases := []struct {
 		name        string
-		expectedCrd *oauth.CRD
+		expectedCrd *configv1.OAuth
 	}{
 		{
 			name:        "build ldap provider",

--- a/pkg/transform/oauth/oauth.go
+++ b/pkg/transform/oauth/oauth.go
@@ -38,18 +38,16 @@ type Provider struct {
 
 // IdentityProvider stores an identity provider
 type IdentityProvider struct {
-	Kind            string
-	APIVersion      string
-	MappingMethod   string
-	Name            string
-	Provider        runtime.RawExtension
-	HTFileName      string
-	HTFileData      []byte
-	CAData          []byte
-	CrtData         []byte
-	KeyData         []byte
-	UseAsChallenger bool
-	UseAsLogin      bool
+	Kind          string
+	APIVersion    string
+	MappingMethod string
+	Name          string
+	Provider      runtime.RawExtension
+	HTFileName    string
+	HTFileData    []byte
+	CAData        []byte
+	CrtData       []byte
+	KeyData       []byte
 }
 
 // Resources stores all oAuth config parts

--- a/pkg/transform/oauth/oauth.go
+++ b/pkg/transform/oauth/oauth.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/fusor/cpma/pkg/transform/configmaps"
 	"github.com/fusor/cpma/pkg/transform/secrets"
+	configv1 "github.com/openshift/api/config/v1"
 	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	oauthv1 "github.com/openshift/api/oauth/v1"
 	"github.com/sirupsen/logrus"
@@ -24,39 +25,6 @@ func init() {
 //   [v4] OCPv4:
 //   - [2] htpasswd: https://docs.openshift.com/container-platform/4.0/authentication/understanding-identity-provider.html
 //   - [3] github: https://docs.openshift.com/container-platform/4.0/authentication/identity_providers/configuring-github-identity-provider.html
-
-// CRD Shared CRD part, present in all types of OAuth CRDs
-type CRD struct {
-	APIVersion string   `json:"apiVersion"`
-	Kind       string   `json:"kind"`
-	Metadata   MetaData `json:"metadata"`
-	Spec       Spec     `json:"spec"`
-}
-
-// Spec is a CRD Spec
-type Spec struct {
-	IdentityProviders []interface{}         `json:"identityProviders,omitempty"`
-	TokenConfig       TranslatedTokenConfig `json:"tokenConfig,omitempty"`
-}
-
-// TranslatedTokenConfig holds lifetime of access tokens
-type TranslatedTokenConfig struct {
-	AccessTokenMaxAgeSeconds int32 `json:"accessTokenMaxAgeSeconds"`
-}
-
-type identityProviderCommon struct {
-	Name          string `json:"name"`
-	Challenge     bool   `json:"challenge"`
-	Login         bool   `json:"login"`
-	MappingMethod string `json:"mappingMethod"`
-	Type          string `json:"type"`
-}
-
-// MetaData contains CRD Metadata
-type MetaData struct {
-	Name      string `json:"name"`
-	NameSpace string `json:"namespace"`
-}
 
 // Provider contains an identity providers type specific provider data
 type Provider struct {
@@ -86,7 +54,7 @@ type IdentityProvider struct {
 
 // Resources stores all oAuth config parts
 type Resources struct {
-	OAuthCRD   *CRD
+	OAuthCRD   *configv1.OAuth
 	Secrets    []*secrets.Secret
 	ConfigMaps []*configmaps.ConfigMap
 }
@@ -107,16 +75,16 @@ const (
 // Translate converts OCPv3 OAuth to OCPv4 OAuth Custom Resources
 func Translate(identityProviders []IdentityProvider, tokenConfig TokenConfig) (*Resources, error) {
 	var err error
-	var idP interface{}
+	var idP *configv1.IdentityProvider
 	var secretsSlice []*secrets.Secret
 	var сonfigMapSlice []*configmaps.ConfigMap
 
 	// Translate configuration of diffent oAuth providers to CRD, secrets and config maps
-	var oauthCrd CRD
+	var oauthCrd configv1.OAuth
 	oauthCrd.APIVersion = APIVersion
 	oauthCrd.Kind = "OAuth"
-	oauthCrd.Metadata.Name = "cluster"
-	oauthCrd.Metadata.NameSpace = OAuthNamespace
+	oauthCrd.Name = "cluster"
+	oauthCrd.Namespace = OAuthNamespace
 	serializer := json.NewYAMLSerializer(json.DefaultMetaFactory, scheme.Scheme, scheme.Scheme)
 	for _, p := range identityProviders {
 		var secret, certSecret, keySecret *secrets.Secret
@@ -175,7 +143,7 @@ func Translate(identityProviders []IdentityProvider, tokenConfig TokenConfig) (*
 			сonfigMapSlice = append(сonfigMapSlice, caConfigMap)
 		}
 
-		oauthCrd.Spec.IdentityProviders = append(oauthCrd.Spec.IdentityProviders, idP)
+		oauthCrd.Spec.IdentityProviders = append(oauthCrd.Spec.IdentityProviders, *idP)
 	}
 
 	// Translate lifetime of access tokens

--- a/pkg/transform/oauth/oauth_test.go
+++ b/pkg/transform/oauth/oauth_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/fusor/cpma/pkg/transform/oauth"
+	configv1 "github.com/openshift/api/config/v1"
 	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -37,14 +38,12 @@ func TestTransformMasterConfig(t *testing.T) {
 
 		identityProviders = append(identityProviders,
 			oauth.IdentityProvider{
-				Kind:            provider.Kind,
-				APIVersion:      provider.APIVersion,
-				MappingMethod:   identityProvider.MappingMethod,
-				Name:            identityProvider.Name,
-				Provider:        identityProvider.Provider,
-				HTFileName:      provider.File,
-				UseAsChallenger: identityProvider.UseAsChallenger,
-				UseAsLogin:      identityProvider.UseAsLogin,
+				Kind:          provider.Kind,
+				APIVersion:    provider.APIVersion,
+				MappingMethod: identityProvider.MappingMethod,
+				Name:          identityProvider.Name,
+				Provider:      identityProvider.Provider,
+				HTFileName:    provider.File,
 			})
 	}
 
@@ -61,15 +60,15 @@ func TestTransformMasterConfig(t *testing.T) {
 			oauthResources, err := oauth.Translate(identityProviders, oauth.TokenConfig{AccessTokenMaxAgeSeconds: 42000, AuthorizeTokenMaxAgeSeconds: 42000})
 			require.NoError(t, err)
 			assert.Equal(t, 9, len(oauthResources.OAuthCRD.Spec.IdentityProviders))
-			assert.Equal(t, "BasicAuth", oauthResources.OAuthCRD.Spec.IdentityProviders[0].(*oauth.IdentityProviderBasicAuth).Type)
-			assert.Equal(t, "GitHub", oauthResources.OAuthCRD.Spec.IdentityProviders[1].(*oauth.IdentityProviderGitHub).Type)
-			assert.Equal(t, "GitLab", oauthResources.OAuthCRD.Spec.IdentityProviders[2].(*oauth.IdentityProviderGitLab).Type)
-			assert.Equal(t, "Google", oauthResources.OAuthCRD.Spec.IdentityProviders[3].(*oauth.IdentityProviderGoogle).Type)
-			assert.Equal(t, "HTPasswd", oauthResources.OAuthCRD.Spec.IdentityProviders[4].(*oauth.IdentityProviderHTPasswd).Type)
-			assert.Equal(t, "Keystone", oauthResources.OAuthCRD.Spec.IdentityProviders[5].(*oauth.IdentityProviderKeystone).Type)
-			assert.Equal(t, "LDAP", oauthResources.OAuthCRD.Spec.IdentityProviders[6].(*oauth.IdentityProviderLDAP).Type)
-			assert.Equal(t, "RequestHeader", oauthResources.OAuthCRD.Spec.IdentityProviders[7].(*oauth.IdentityProviderRequestHeader).Type)
-			assert.Equal(t, "OpenID", oauthResources.OAuthCRD.Spec.IdentityProviders[8].(*oauth.IdentityProviderOpenID).Type)
+			assert.Equal(t, configv1.IdentityProviderType("BasicAuth"), oauthResources.OAuthCRD.Spec.IdentityProviders[0].Type)
+			assert.Equal(t, configv1.IdentityProviderType("GitHub"), oauthResources.OAuthCRD.Spec.IdentityProviders[1].Type)
+			assert.Equal(t, configv1.IdentityProviderType("GitLab"), oauthResources.OAuthCRD.Spec.IdentityProviders[2].Type)
+			assert.Equal(t, configv1.IdentityProviderType("Google"), oauthResources.OAuthCRD.Spec.IdentityProviders[3].Type)
+			assert.Equal(t, configv1.IdentityProviderType("HTPasswd"), oauthResources.OAuthCRD.Spec.IdentityProviders[4].Type)
+			assert.Equal(t, configv1.IdentityProviderType("Keystone"), oauthResources.OAuthCRD.Spec.IdentityProviders[5].Type)
+			assert.Equal(t, configv1.IdentityProviderType("LDAP"), oauthResources.OAuthCRD.Spec.IdentityProviders[6].Type)
+			assert.Equal(t, configv1.IdentityProviderType("RequestHeader"), oauthResources.OAuthCRD.Spec.IdentityProviders[7].Type)
+			assert.Equal(t, configv1.IdentityProviderType("OpenID"), oauthResources.OAuthCRD.Spec.IdentityProviders[8].Type)
 
 			assert.Equal(t, int32(42000), oauthResources.OAuthCRD.Spec.TokenConfig.AccessTokenMaxAgeSeconds)
 		})

--- a/pkg/transform/oauth/openid.go
+++ b/pkg/transform/oauth/openid.go
@@ -26,6 +26,7 @@ func buildOpenIDIP(serializer *json.Serializer, p IdentityProvider) (*configv1.I
 	idP.Type = "OpenID"
 	idP.Name = p.Name
 	idP.MappingMethod = configv1.MappingMethodType(p.MappingMethod)
+	idP.OpenID = &configv1.OpenIDIdentityProvider{}
 	idP.OpenID.ClientID = openID.ClientID
 	idP.OpenID.Claims.PreferredUsername = openID.Claims.PreferredUsername
 	idP.OpenID.Claims.Name = openID.Claims.Name

--- a/pkg/transform/oauth/openid_test.go
+++ b/pkg/transform/oauth/openid_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/fusor/cpma/pkg/transform/oauth"
 	cpmatest "github.com/fusor/cpma/pkg/utils/test"
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -14,31 +15,28 @@ func TestTransformMasterConfigOpenID(t *testing.T) {
 	identityProviders, err := cpmatest.LoadIPTestData("testdata/openid/master_config.yaml")
 	require.NoError(t, err)
 
-	var expectedCrd oauth.CRD
+	var expectedCrd configv1.OAuth
 	expectedCrd.APIVersion = "config.openshift.io/v1"
 	expectedCrd.Kind = "OAuth"
-	expectedCrd.Metadata.Name = "cluster"
-	expectedCrd.Metadata.NameSpace = oauth.OAuthNamespace
+	expectedCrd.Name = "cluster"
+	expectedCrd.Namespace = oauth.OAuthNamespace
 
-	var openidIDP = &oauth.IdentityProviderOpenID{}
+	var openidIDP = &configv1.IdentityProvider{}
 	openidIDP.Type = "OpenID"
-	openidIDP.Challenge = false
-	openidIDP.Login = true
 	openidIDP.MappingMethod = "claim"
 	openidIDP.Name = "my_openid_connect"
+	openidIDP.OpenID = &configv1.OpenIDIdentityProvider{}
 	openidIDP.OpenID.ClientID = "testid"
 	openidIDP.OpenID.Claims.PreferredUsername = []string{"preferred_username", "email"}
 	openidIDP.OpenID.Claims.Name = []string{"nickname", "given_name", "name"}
 	openidIDP.OpenID.Claims.Email = []string{"custom_email_claim", "email"}
-	openidIDP.OpenID.URLs.Authorize = "https://myidp.example.com/oauth2/authorize"
-	openidIDP.OpenID.URLs.Token = "https://myidp.example.com/oauth2/token"
 	openidIDP.OpenID.ClientSecret.Name = "my_openid_connect-secret"
 
-	expectedCrd.Spec.IdentityProviders = append(expectedCrd.Spec.IdentityProviders, openidIDP)
+	expectedCrd.Spec.IdentityProviders = append(expectedCrd.Spec.IdentityProviders, *openidIDP)
 
 	testCases := []struct {
 		name        string
-		expectedCrd *oauth.CRD
+		expectedCrd *configv1.OAuth
 	}{
 		{
 			name:        "build openid provider",

--- a/pkg/transform/oauth/requestheader.go
+++ b/pkg/transform/oauth/requestheader.go
@@ -23,6 +23,7 @@ func buildRequestHeaderIP(serializer *json.Serializer, p IdentityProvider) (*con
 	idP.Type = "RequestHeader"
 	idP.Name = p.Name
 	idP.MappingMethod = configv1.MappingMethodType(p.MappingMethod)
+	idP.RequestHeader = &configv1.RequestHeaderIdentityProvider{}
 	idP.RequestHeader.ChallengeURL = requestHeader.ChallengeURL
 	idP.RequestHeader.LoginURL = requestHeader.LoginURL
 

--- a/pkg/transform/oauth/requestheader.go
+++ b/pkg/transform/oauth/requestheader.go
@@ -2,33 +2,16 @@ package oauth
 
 import (
 	"github.com/fusor/cpma/pkg/transform/configmaps"
+	configv1 "github.com/openshift/api/config/v1"
 	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
-// IdentityProviderRequestHeader is a request header specific identity provider
-type IdentityProviderRequestHeader struct {
-	identityProviderCommon `json:",inline"`
-	RequestHeader          RequestHeader `json:"requestHeader"`
-}
-
-// RequestHeader provider specific data
-type RequestHeader struct {
-	ChallengeURL             string   `json:"challengeURL,omitempty"`
-	LoginURL                 string   `json:"loginURL,omitempty"`
-	CA                       *CA      `json:"ca,omitempty"`
-	ClientCommonNames        []string `json:"сlientCommonNames,omitempty"`
-	Headers                  []string `json:"headers"`
-	EmailHeaders             []string `json:"emailHeaders,omitempty"`
-	NameHeaders              []string `json:"nameHeaders,omitempty"`
-	PreferredUsernameHeaders []string `json:"preferredUsernameHeaders,omitempty"`
-}
-
-func buildRequestHeaderIP(serializer *json.Serializer, p IdentityProvider) (*IdentityProviderRequestHeader, *configmaps.ConfigMap, error) {
+func buildRequestHeaderIP(serializer *json.Serializer, p IdentityProvider) (*configv1.IdentityProvider, *configmaps.ConfigMap, error) {
 	var (
 		err           error
-		idP           = &IdentityProviderRequestHeader{}
+		idP           = &configv1.IdentityProvider{}
 		caConfigmap   *configmaps.ConfigMap
 		requestHeader legacyconfigv1.RequestHeaderIdentityProvider
 	)
@@ -39,15 +22,13 @@ func buildRequestHeaderIP(serializer *json.Serializer, p IdentityProvider) (*Ide
 
 	idP.Type = "RequestHeader"
 	idP.Name = p.Name
-	idP.Challenge = p.UseAsChallenger
-	idP.Login = p.UseAsLogin
-	idP.MappingMethod = p.MappingMethod
+	idP.MappingMethod = configv1.MappingMethodType(p.MappingMethod)
 	idP.RequestHeader.ChallengeURL = requestHeader.ChallengeURL
 	idP.RequestHeader.LoginURL = requestHeader.LoginURL
 
 	if requestHeader.ClientCA != "" {
 		caConfigmap = configmaps.GenConfigMap("requestheader-configmap", OAuthNamespace, p.CAData)
-		idP.RequestHeader.CA = &CA{Name: caConfigmap.Metadata.Name}
+		idP.RequestHeader.ClientCA = configv1.ConfigMapNameReference{Name: caConfigmap.Metadata.Name}
 	}
 
 	idP.RequestHeader.ClientCommonNames = requestHeader.ClientCommonNames

--- a/pkg/transform/oauth_transform.go
+++ b/pkg/transform/oauth_transform.go
@@ -256,18 +256,16 @@ func (e OAuthTransform) Extract() (Extraction, error) {
 
 			extraction.IdentityProviders = append(extraction.IdentityProviders,
 				oauth.IdentityProvider{
-					Kind:            provider.Kind,
-					APIVersion:      provider.APIVersion,
-					MappingMethod:   identityProvider.MappingMethod,
-					Name:            identityProvider.Name,
-					Provider:        identityProvider.Provider,
-					HTFileName:      provider.File,
-					HTFileData:      htContent,
-					CAData:          caContent,
-					CrtData:         crtContent,
-					KeyData:         keyContent,
-					UseAsChallenger: identityProvider.UseAsChallenger,
-					UseAsLogin:      identityProvider.UseAsLogin,
+					Kind:          provider.Kind,
+					APIVersion:    provider.APIVersion,
+					MappingMethod: identityProvider.MappingMethod,
+					Name:          identityProvider.Name,
+					Provider:      identityProvider.Provider,
+					HTFileName:    provider.File,
+					HTFileData:    htContent,
+					CAData:        caContent,
+					CrtData:       crtContent,
+					KeyData:       keyContent,
 				})
 		}
 	}

--- a/pkg/transform/testdata/expected-CR-oauth.yaml
+++ b/pkg/transform/testdata/expected-CR-oauth.yaml
@@ -1,6 +1,7 @@
 apiVersion: config.openshift.io/v1
 kind: OAuth
 metadata:
+  creationTimestamp: null
   name: cluster
   namespace: openshift-config
 spec:
@@ -13,13 +14,10 @@ spec:
       tlsClientKey:
         name: my_remote_basic_auth_provider-client-key-secret
       url: https://www.example.com/
-    challenge: true
-    login: true
     mappingMethod: claim
     name: my_remote_basic_auth_provider
     type: BasicAuth
-  - challenge: false
-    github:
+  - github:
       ca:
         name: github-configmap
       clientID: 2d85ea3f45d6777bffd7
@@ -32,42 +30,34 @@ spec:
       teams:
       - myorganization1/team-a
       - myorganization2/team-b
-    login: true
     mappingMethod: claim
     name: github123456789
     type: GitHub
-  - challenge: true
-    gitlab:
+  - gitlab:
       ca:
         name: gitlab-configmap
       clientID: fake-id
       clientSecret:
         name: gitlab123456789-secret
       url: https://gitlab.com/
-    login: true
     mappingMethod: claim
     name: gitlab123456789
     type: GitLab
-  - challenge: false
-    google:
+  - google:
       clientID: 82342890327-tf5lqn4eikdf4cb4edfm85jiqotvurpq.apps.googleusercontent.com
       clientSecret:
         name: google123456789123456789-secret
       hostedDomain: test.example.com
-    login: true
     mappingMethod: claim
     name: google123456789123456789
     type: Google
-  - challenge: true
-    htpasswd:
+  - htpasswd:
       fileData:
         name: htpasswd_auth-secret
-    login: true
     mappingMethod: claim
     name: htpasswd_auth
     type: HTPasswd
-  - challenge: true
-    keystone:
+  - keystone:
       ca:
         name: keystone-configmap
       domainName: default
@@ -76,12 +66,10 @@ spec:
       tlsClientKey:
         name: my_keystone_provider-client-key-secret
       url: http://fake.url:5000
-    login: true
     mappingMethod: claim
     name: my_keystone_provider
     type: Keystone
-  - challenge: true
-    ldap:
+  - ldap:
       attributes:
         email:
         - mail
@@ -92,23 +80,23 @@ spec:
         preferredUsername:
         - uid
       bindDN: "123"
-      bindPassword: "321"
+      bindPassword:
+        name: "321"
       ca:
         name: ldap-configmap
       insecure: false
       url: ldap://ldap.example.com/ou=users,dc=acme,dc=com?uid
-    login: true
     mappingMethod: claim
     name: my_ldap_provider
     type: LDAP
-  - challenge: true
-    login: true
-    mappingMethod: claim
+  - mappingMethod: claim
     name: my_request_header_provider
     requestHeader:
       ca:
         name: requestheader-configmap
       challengeURL: https://example.com
+      clientCommonNames:
+      - my-auth-proxy
       emailHeaders:
       - X-Remote-User-Email
       headers:
@@ -119,14 +107,12 @@ spec:
       - X-Remote-User-Display-Name
       preferredUsernameHeaders:
       - X-Remote-User-Login
-      сlientCommonNames:
-      - my-auth-proxy
     type: RequestHeader
-  - challenge: false
-    login: true
-    mappingMethod: claim
+  - mappingMethod: claim
     name: my_openid_connect
     openID:
+      ca:
+        name: ""
       claims:
         email:
         - custom_email_claim
@@ -141,9 +127,15 @@ spec:
       clientID: testid
       clientSecret:
         name: my_openid_connect-secret
-      urls:
-        authorize: https://myidp.example.com/oauth2/authorize
-        token: https://myidp.example.com/oauth2/token
+      issuer: ""
     type: OpenID
+  templates:
+    error:
+      name: ""
+    login:
+      name: ""
+    providerSelection:
+      name: ""
   tokenConfig:
     accessTokenMaxAgeSeconds: 86400
+status: {}

--- a/pkg/transform/testdata/expected-master_config-oauth-bulk.yaml
+++ b/pkg/transform/testdata/expected-master_config-oauth-bulk.yaml
@@ -1,6 +1,7 @@
 apiVersion: config.openshift.io/v1
 kind: OAuth
 metadata:
+  creationTimestamp: null
   name: cluster
   namespace: openshift-config
 spec:
@@ -13,13 +14,10 @@ spec:
       tlsClientKey:
         name: my_remote_basic_auth_provider-client-key-secret
       url: https://www.example.com/
-    challenge: true
-    login: true
     mappingMethod: claim
     name: my_remote_basic_auth_provider
     type: BasicAuth
-  - challenge: false
-    github:
+  - github:
       ca:
         name: github-configmap
       clientID: 2d85ea3f45d6777bffd7
@@ -32,42 +30,34 @@ spec:
       teams:
       - myorganization1/team-a
       - myorganization2/team-b
-    login: true
     mappingMethod: claim
     name: github123456789
     type: GitHub
-  - challenge: true
-    gitlab:
+  - gitlab:
       ca:
         name: gitlab-configmap
       clientID: fake-id
       clientSecret:
         name: gitlab123456789-secret
       url: https://gitlab.com/
-    login: true
     mappingMethod: claim
     name: gitlab123456789
     type: GitLab
-  - challenge: false
-    google:
+  - google:
       clientID: 82342890327-tf5lqn4eikdf4cb4edfm85jiqotvurpq.apps.googleusercontent.com
       clientSecret:
         name: google123456789123456789-secret
       hostedDomain: test.example.com
-    login: true
     mappingMethod: claim
     name: google123456789123456789
     type: Google
-  - challenge: true
-    htpasswd:
+  - htpasswd:
       fileData:
         name: htpasswd_auth-secret
-    login: true
     mappingMethod: claim
     name: htpasswd_auth
     type: HTPasswd
-  - challenge: true
-    keystone:
+  - keystone:
       ca:
         name: keystone-configmap
       domainName: default
@@ -76,12 +66,10 @@ spec:
       tlsClientKey:
         name: my_keystone_provider-client-key-secret
       url: http://fake.url:5000
-    login: true
     mappingMethod: claim
     name: my_keystone_provider
     type: Keystone
-  - challenge: true
-    ldap:
+  - ldap:
       attributes:
         email:
         - mail
@@ -92,23 +80,23 @@ spec:
         preferredUsername:
         - uid
       bindDN: "123"
-      bindPassword: "321"
+      bindPassword:
+        name: "321"
       ca:
         name: ldap-configmap
       insecure: false
       url: ldap://ldap.example.com/ou=users,dc=acme,dc=com?uid
-    login: true
     mappingMethod: claim
     name: my_ldap_provider
     type: LDAP
-  - challenge: true
-    login: true
-    mappingMethod: claim
+  - mappingMethod: claim
     name: my_request_header_provider
     requestHeader:
       ca:
         name: requestheader-configmap
       challengeURL: https://example.com
+      clientCommonNames:
+      - my-auth-proxy
       emailHeaders:
       - X-Remote-User-Email
       headers:
@@ -119,14 +107,12 @@ spec:
       - X-Remote-User-Display-Name
       preferredUsernameHeaders:
       - X-Remote-User-Login
-      сlientCommonNames:
-      - my-auth-proxy
     type: RequestHeader
-  - challenge: false
-    login: true
-    mappingMethod: claim
+  - mappingMethod: claim
     name: my_openid_connect
     openID:
+      ca:
+        name: ""
       claims:
         email:
         - custom_email_claim
@@ -141,9 +127,15 @@ spec:
       clientID: testid
       clientSecret:
         name: my_openid_connect-secret
-      urls:
-        authorize: https://myidp.example.com/oauth2/authorize
-        token: https://myidp.example.com/oauth2/token
+      issuer: ""
     type: OpenID
+  templates:
+    error:
+      name: ""
+    login:
+      name: ""
+    providerSelection:
+      name: ""
   tokenConfig:
     accessTokenMaxAgeSeconds: 86400
+status: {}

--- a/pkg/transform/testdata/expected-master_config-oauth-omit-empty-values.yaml
+++ b/pkg/transform/testdata/expected-master_config-oauth-omit-empty-values.yaml
@@ -1,63 +1,69 @@
 apiVersion: config.openshift.io/v1
 kind: OAuth
 metadata:
+  creationTimestamp: null
   name: cluster
   namespace: openshift-config
 spec:
   identityProviders:
   - basicAuth:
+      ca:
+        name: ""
+      tlsClientCert:
+        name: ""
+      tlsClientKey:
+        name: ""
       url: https://www.example.com/
-    challenge: true
-    login: true
     mappingMethod: claim
     name: my_remote_basic_auth_provider
     type: BasicAuth
-  - challenge: false
-    github:
+  - github:
+      ca:
+        name: ""
       clientID: 2d85ea3f45d6777bffd7
       clientSecret:
         name: github123456789-secret
-    login: true
+      hostname: ""
     mappingMethod: claim
     name: github123456789
     type: GitHub
-  - challenge: true
-    gitlab:
+  - gitlab:
+      ca:
+        name: ""
       clientID: fake-id
       clientSecret:
         name: gitlab123456789-secret
       url: https://gitlab.com/
-    login: true
     mappingMethod: claim
     name: gitlab123456789
     type: GitLab
-  - challenge: false
-    google:
+  - google:
       clientID: 82342890327-tf5lqn4eikdf4cb4edfm85jiqotvurpq.apps.googleusercontent.com
       clientSecret:
         name: google123456789123456789-secret
-    login: true
+      hostedDomain: ""
     mappingMethod: claim
     name: google123456789123456789
     type: Google
-  - challenge: true
-    htpasswd:
+  - htpasswd:
       fileData:
         name: htpasswd_auth-secret
-    login: true
     mappingMethod: claim
     name: htpasswd_auth
     type: HTPasswd
-  - challenge: true
-    keystone:
+  - keystone:
+      ca:
+        name: ""
       domainName: default
+      tlsClientCert:
+        name: ""
+      tlsClientKey:
+        name: ""
       url: http://fake.url:5000
-    login: true
     mappingMethod: claim
     name: my_keystone_provider
     type: Keystone
-  - challenge: true
-    ldap:
+  - ldap:
       attributes:
         email:
         - mail
@@ -67,26 +73,35 @@ spec:
         - cn
         preferredUsername:
         - uid
+      bindDN: ""
+      bindPassword:
+        name: ""
+      ca:
+        name: ""
       insecure: false
       url: ldap://ldap.example.com/ou=users,dc=acme,dc=com?uid
-    login: true
     mappingMethod: claim
     name: my_ldap_provider
     type: LDAP
-  - challenge: true
-    login: true
-    mappingMethod: claim
+  - mappingMethod: claim
     name: my_request_header_provider
     requestHeader:
+      ca:
+        name: ""
+      challengeURL: ""
+      emailHeaders: null
       headers:
       - X-Remote-User
       - SSO-User
+      loginURL: ""
+      nameHeaders: null
+      preferredUsernameHeaders: null
     type: RequestHeader
-  - challenge: false
-    login: true
-    mappingMethod: claim
+  - mappingMethod: claim
     name: my_openid_connect
     openID:
+      ca:
+        name: ""
       claims:
         email:
         - custom_email_claim
@@ -101,9 +116,15 @@ spec:
       clientID: testid
       clientSecret:
         name: my_openid_connect-secret
-      urls:
-        authorize: https://myidp.example.com/oauth2/authorize
-        token: https://myidp.example.com/oauth2/token
+      issuer: ""
     type: OpenID
+  templates:
+    error:
+      name: ""
+    login:
+      name: ""
+    providerSelection:
+      name: ""
   tokenConfig:
     accessTokenMaxAgeSeconds: 86400
+status: {}

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -5,9 +5,8 @@ import (
 	"github.com/fusor/cpma/pkg/transform/configmaps"
 	"github.com/fusor/cpma/pkg/transform/secrets"
 	"github.com/ghodss/yaml"
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/sirupsen/logrus"
-		configv1 "github.com/openshift/api/config/v1"
-
 )
 
 const (

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -3,10 +3,11 @@ package transform
 import (
 	"github.com/fusor/cpma/pkg/io"
 	"github.com/fusor/cpma/pkg/transform/configmaps"
-	"github.com/fusor/cpma/pkg/transform/oauth"
 	"github.com/fusor/cpma/pkg/transform/secrets"
 	"github.com/ghodss/yaml"
 	"github.com/sirupsen/logrus"
+		configv1 "github.com/openshift/api/config/v1"
+
 )
 
 const (
@@ -35,7 +36,7 @@ type Cluster struct {
 
 // Master is a cluster Master
 type Master struct {
-	OAuth      oauth.CRD
+	OAuth      configv1.OAuth
 	Secrets    []*secrets.Secret
 	ConfigMaps []*configmaps.ConfigMap
 }

--- a/pkg/transform/transform_test.go
+++ b/pkg/transform/transform_test.go
@@ -64,14 +64,12 @@ func TestOauthGenYAML(t *testing.T) {
 
 				identityProviders = append(identityProviders,
 					oauth.IdentityProvider{
-						Kind:            provider.Kind,
-						APIVersion:      provider.APIVersion,
-						MappingMethod:   identityProvider.MappingMethod,
-						Name:            identityProvider.Name,
-						Provider:        identityProvider.Provider,
-						HTFileName:      provider.File,
-						UseAsChallenger: identityProvider.UseAsChallenger,
-						UseAsLogin:      identityProvider.UseAsLogin,
+						Kind:          provider.Kind,
+						APIVersion:    provider.APIVersion,
+						MappingMethod: identityProvider.MappingMethod,
+						Name:          identityProvider.Name,
+						Provider:      identityProvider.Provider,
+						HTFileName:    provider.File,
 					})
 			}
 

--- a/pkg/utils/test/load_test_data.go
+++ b/pkg/utils/test/load_test_data.go
@@ -42,14 +42,12 @@ func LoadIPTestData(file string) ([]oauth.IdentityProvider, error) {
 
 		identityProviders = append(identityProviders,
 			oauth.IdentityProvider{
-				Kind:            provider.Kind,
-				APIVersion:      provider.APIVersion,
-				MappingMethod:   identityProvider.MappingMethod,
-				Name:            identityProvider.Name,
-				Provider:        identityProvider.Provider,
-				HTFileName:      provider.File,
-				UseAsChallenger: identityProvider.UseAsChallenger,
-				UseAsLogin:      identityProvider.UseAsLogin,
+				Kind:          provider.Kind,
+				APIVersion:    provider.APIVersion,
+				MappingMethod: identityProvider.MappingMethod,
+				Name:          identityProvider.Name,
+				Provider:      identityProvider.Provider,
+				HTFileName:    provider.File,
 			})
 	}
 


### PR DESCRIPTION
After changes introduced in this PR, OAuth manifest will look like this:
```
apiVersion: config.openshift.io/v1
kind: OAuth
metadata:
  creationTimestamp: null
  name: cluster
  namespace: openshift-config
spec:
  identityProviders:
  - htpasswd:
      fileData:
        name: htpasswd_auth-secret
    mappingMethod: claim
    name: htpasswd_auth
    type: HTPasswd
  templates:
    error:
      name: ""
    login:
      name: ""
    providerSelection:
      name: ""
  tokenConfig:
    accessTokenMaxAgeSeconds: 86400
status: {}
```
There is one issue I see: we can't omit empty entries like `templates`, I will try to deploy OCP4 using this and fix CI if deployment succeeds.