### PR TITLE
Remove comments and json suffixe to log file

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -17,9 +17,7 @@ import (
 const (
 	// AppName holds the name of this application
 	AppName = "CPMA"
-
-	// logFile - keeps full path to the logging file
-	logFile = "cpma.log.json" // TODO: we may want this configurable
+	logFile = "cpma.log"
 )
 
 var (


### PR DESCRIPTION
If log file is not JSON valid then let's not call it such.

Re todo comment, well the file name is static for now.