### PR TITLE
Extended cluster report

### DIFF
--- a/pkg/transform/cluster_report_transform.go
+++ b/pkg/transform/cluster_report_transform.go
@@ -1,11 +1,14 @@
 package transform
 
 import (
+	"strconv"
+
 	"github.com/fusor/cpma/pkg/api"
 	O7tapiroute "github.com/openshift/api/route/v1"
 	"github.com/sirupsen/logrus"
 
 	k8sapicore "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // ClusterReportName is the cluster report name
@@ -28,6 +31,7 @@ func (e ClusterReportExtraction) Transform() ([]Output, error) {
 		PersistentVolumeList: e.PersistentVolumeList,
 		StorageClassList:     e.StorageClassList,
 		NamespaceMap:         e.NamespaceMap,
+		NodeList:             e.NodeList,
 	})
 	if err != nil {
 		return nil, err
@@ -41,14 +45,61 @@ func (e ClusterReportExtraction) Transform() ([]Output, error) {
 	return outputs, nil
 }
 
-func genClusterReport(apiResources api.Resources) (ClusterReport, error) {
-	clusterReport := ClusterReport{}
+// genClusterReport inserts report values into structures for json output
+func genClusterReport(apiResources api.Resources) (clusterReport ClusterReport, err error) {
+	clusterReport.reportNodes(apiResources)
 	clusterReport.reportNamespaces(apiResources)
 	clusterReport.reportPVs(apiResources)
 	clusterReport.reportStorageClasses(apiResources)
-	return clusterReport, nil
+	return
 }
 
+// reportNodes fills in information about nodes
+func (clusterReport *ClusterReport) reportNodes(apiResources api.Resources) {
+	logrus.Debug("ClusterReport::ReportNodes")
+
+	for _, node := range apiResources.NodeList.Items {
+		nodeReport := &NodeReport{
+			Name: node.ObjectMeta.Name,
+		}
+
+		isMaster, ok := node.ObjectMeta.Labels["node-role.kubernetes.io/master"]
+		if ok && isMaster == "true" {
+			nodeReport.MasterNode = true
+		} else {
+			nodeReport.MasterNode = false
+		}
+
+		reportResources(nodeReport, node.Status, apiResources)
+		clusterReport.Nodes = append(clusterReport.Nodes, *nodeReport)
+	}
+}
+
+// reportResources parse and insert info about consumed resources
+func reportResources(repotedNode *NodeReport, nodeStatus k8sapicore.NodeStatus, apiResources api.Resources) {
+	repotedNode.Resources.CPU = nodeStatus.Capacity.Cpu().String()
+
+	repotedNode.Resources.MemoryCapacity = nodeStatus.Capacity.Memory().String()
+
+	memConsumed := new(resource.Quantity)
+	memCapacity, _ := nodeStatus.Capacity.Memory().AsInt64()
+	memAllocatable, _ := nodeStatus.Allocatable.Memory().AsInt64()
+	memConsumed.Set(memCapacity - memAllocatable)
+	memConsumed.Format = resource.BinarySI
+	repotedNode.Resources.MemoryConsumed = memConsumed.String()
+
+	runningPods := 0
+	for _, resources := range apiResources.NamespaceMap {
+		for _, pod := range resources.PodList.Items {
+			if pod.Spec.NodeName == repotedNode.Name {
+				runningPods++
+			}
+		}
+	}
+	repotedNode.Resources.RunningPods = strconv.Itoa(runningPods) + "/" + nodeStatus.Capacity.Pods().String()
+}
+
+// reportNamespaces fills in information about Namespaces
 func (clusterReport *ClusterReport) reportNamespaces(apiResources api.Resources) {
 	logrus.Debug("ClusterReport::ReportNamespaces")
 
@@ -64,6 +115,7 @@ func (clusterReport *ClusterReport) reportNamespaces(apiResources api.Resources)
 	}
 }
 
+// reportPods creates info about cluster pods
 func reportPods(reportedNamespace *NamespaceReport, podList *k8sapicore.PodList) {
 	for _, pod := range podList.Items {
 		reportedPod := &PodReport{
@@ -98,7 +150,10 @@ func (clusterReport *ClusterReport) reportPVs(apiResources api.Resources) {
 	for _, pv := range pvList.Items {
 		reportedPV := &PVReport{
 			Name:         pv.Name,
+			Driver:       pv.Spec.PersistentVolumeSource,
 			StorageClass: pv.Spec.StorageClassName,
+			Capacity:     pv.Spec.Capacity,
+			Phase:        pv.Status.Phase,
 		}
 
 		clusterReport.PVs = append(clusterReport.PVs, *reportedPV)
@@ -127,6 +182,12 @@ func (e ClusterReportExtraction) Validate() error {
 // Extract collects data for cluster report
 func (e ClusterTransform) Extract() (Extraction, error) {
 	extraction := &ClusterReportExtraction{}
+
+	nodeList, err := api.ListNodes()
+	if err != nil {
+		return nil, err
+	}
+	extraction.NodeList = nodeList
 
 	namespacesList, err := api.ListNamespaces()
 	if err != nil {

--- a/pkg/transform/report_output.go
+++ b/pkg/transform/report_output.go
@@ -7,6 +7,7 @@ import (
 	O7tapiroute "github.com/openshift/api/route/v1"
 	"github.com/sirupsen/logrus"
 	k8sapicore "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // ReportOutput holds a collection of reports to be written to file
@@ -17,10 +18,11 @@ type ReportOutput struct {
 
 // NodeResources represents a json report of Node resources
 type NodeResources struct {
-	CPU            string `json:"cpu"`
-	MemoryConsumed string `json:"memoryConsumed"`
-	MemoryCapacity string `json:"memoryCapacity"`
-	RunningPods    string `json:"runningPods"`
+	CPU            *resource.Quantity `json:"cpu"`
+	MemoryConsumed *resource.Quantity `json:"memoryConsumed"`
+	MemoryCapacity *resource.Quantity `json:"memoryCapacity"`
+	RunningPods    *resource.Quantity `json:"runningPods"`
+	PodCapacity    *resource.Quantity `json:"podCapacity"`
 }
 
 // ComponentReport holds a collection of ocp3 config reports

--- a/pkg/transform/report_output.go
+++ b/pkg/transform/report_output.go
@@ -6,12 +6,21 @@ import (
 	"github.com/fusor/cpma/pkg/io"
 	O7tapiroute "github.com/openshift/api/route/v1"
 	"github.com/sirupsen/logrus"
+	k8sapicore "k8s.io/api/core/v1"
 )
 
 // ReportOutput holds a collection of reports to be written to file
 type ReportOutput struct {
 	ClusterReport    ClusterReport     `json:"cluster"`
 	ComponentReports []ComponentReport `json:"components"`
+}
+
+// NodeResources represents a json report of Node resources
+type NodeResources struct {
+	CPU            string `json:"cpu"`
+	MemoryConsumed string `json:"memoryConsumed"`
+	MemoryCapacity string `json:"memoryCapacity"`
+	RunningPods    string `json:"runningPods"`
 }
 
 // ComponentReport holds a collection of ocp3 config reports
@@ -22,9 +31,17 @@ type ComponentReport struct {
 
 // ClusterReport represents json report of k8s resources
 type ClusterReport struct {
+	Nodes          []NodeReport         `json:"nodes"`
 	Namespaces     []NamespaceReport    `json:"namespaces,omitempty"`
 	PVs            []PVReport           `json:"pvs,omitempty"`
 	StorageClasses []StorageClassReport `json:"storageClasses,omitempty"`
+}
+
+// NodeReport represents json report of k8s nodes
+type NodeReport struct {
+	Name       string        `json:"name"`
+	MasterNode bool          `json:"masterNode"`
+	Resources  NodeResources `json:"resources"`
 }
 
 // NamespaceReport represents json report of k8s namespaces
@@ -52,8 +69,11 @@ type RouteReport struct {
 
 // PVReport represents json report of k8s PVs
 type PVReport struct {
-	Name         string `json:"name"`
-	StorageClass string `json:"storageClass,omitempty"`
+	Name         string                            `json:"name"`
+	Driver       k8sapicore.PersistentVolumeSource `json:"driver"`
+	StorageClass string                            `json:"storageClass,omitempty"`
+	Capacity     k8sapicore.ResourceList           `json:"capacity,omitempty"`
+	Phase        k8sapicore.PersistentVolumePhase  `json:"phase,omitempty"`
 }
 
 // StorageClassReport represents json report of k8s storage classes
@@ -88,6 +108,10 @@ func DumpReports(r ReportOutput) {
 	err = json.Unmarshal(jsonData, &existingReports)
 	if err != nil {
 		logrus.Errorf("unable to unmarshal existing report json")
+	}
+
+	for _, node := range r.ClusterReport.Nodes {
+		existingReports.ClusterReport.Nodes = append(existingReports.ClusterReport.Nodes, node)
 	}
 
 	for _, namespace := range r.ClusterReport.Namespaces {


### PR DESCRIPTION
Based on [#231](https://github.com/fusor/cpma/pull/231), closes #251.

- Added info about PV capacity, driver and phase.
- Added node list to output, which contains resource information.
- Master nodes are listed with other nodes by boolean value.

Sample output:
- Nodes: 
```
"nodes": [
   {
    "name": "ip-10-1-1-245.eu-central-1.compute.internal",
    "masterNode": true,
    "resources": {
     "cpu": "4",
     "memoryConsumed": "100Mi",
     "memoryCapacity": "16265188Ki",
     "runningPods": "30",
     "podCapacity": "250"
    }
   }
  ],
...
```
- PVs:
```
"pvs": [
   {
    "name": "pv1",
    "driver": {
     "nfs": {
      "server": "127.0.0.1",
      "path": "/var/lib/nfs/exports/pv1"
     }
    },
    "capacity": {
     "storage": "10G"
    },
    "phase": "Available"
   },
...
```