### PR TITLE
Use local config files

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,8 +15,6 @@
 package cmd
 
 import (
-	"path"
-
 	"github.com/fusor/cpma/pkg/env"
 	"github.com/fusor/cpma/pkg/transform"
 	"github.com/sirupsen/logrus"
@@ -55,7 +53,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&env.Port, "ssh-port", "p", "", "OCP3 ssh port")
 
 	// Get config file from CLI argument an save to viper config
-	rootCmd.PersistentFlags().StringP("output-dir", "o", path.Dir("."), "set the directory to store extracted configuration.")
+	rootCmd.PersistentFlags().StringP("output-dir", "o", "", "set the directory to store extracted configuration.")
 	env.Config().BindPFlag("OutputDir", rootCmd.PersistentFlags().Lookup("output-dir"))
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,6 +55,30 @@ func init() {
 	// Get config file from CLI argument an save to viper config
 	rootCmd.PersistentFlags().StringP("output-dir", "o", "", "set the directory to store extracted configuration.")
 	env.Config().BindPFlag("OutputDir", rootCmd.PersistentFlags().Lookup("output-dir"))
+
+	// Set log level from CLI argument
+	rootCmd.PersistentFlags().String("config-source", "", "source for OCP3 config files, accepted values: remote or local")
+	env.Config().BindPFlag("ConfigSource", rootCmd.PersistentFlags().Lookup("config-source"))
+
+	// Get crio config file location
+	rootCmd.PersistentFlags().String("crio-config", "", "path to crio config file")
+	env.Config().BindPFlag("CrioConfigFile", rootCmd.PersistentFlags().Lookup("crio-config"))
+
+	// Get etcd config file location
+	rootCmd.PersistentFlags().String("etcd-config", "", "path to etcd config file")
+	env.Config().BindPFlag("ETCDConfigFile", rootCmd.PersistentFlags().Lookup("etcd-config"))
+
+	// Get master config file location
+	rootCmd.PersistentFlags().String("master-config", "", "path to master config file")
+	env.Config().BindPFlag("MasterConfigFile", rootCmd.PersistentFlags().Lookup("master-config"))
+
+	// Get node config file location
+	rootCmd.PersistentFlags().String("node-config", "", "path to node config file")
+	env.Config().BindPFlag("NodeConfigFile", rootCmd.PersistentFlags().Lookup("node-config"))
+
+	// Get node config file location
+	rootCmd.PersistentFlags().String("registries-config", "", "path to registries config file")
+	env.Config().BindPFlag("RegistriesConfigFile", rootCmd.PersistentFlags().Lookup("registries-config"))
 }
 
 // rootCmd represents the base command when called without any subcommands

--- a/pkg/api/initclient.go
+++ b/pkg/api/initclient.go
@@ -74,9 +74,6 @@ func CreateK8sClient(contextCluster string) error {
 		return err
 	}
 
-	// set current context to selected cluster for connecting to cluster using client-go
-	KubeConfig.CurrentContext = ClusterNames[contextCluster]
-
 	var kubeConfigGetter = func() (*clientcmdapi.Config, error) {
 		return KubeConfig, nil
 	}
@@ -93,9 +90,6 @@ func CreateK8sClient(contextCluster string) error {
 
 // CreateO7tClient create api client using cluster from kubeconfig context
 func CreateO7tClient(contextCluster string) error {
-	// set current context to selected cluster for connecting to cluster using client-go
-	KubeConfig.CurrentContext = ClusterNames[contextCluster]
-
 	var kubeConfigGetter = func() (*clientcmdapi.Config, error) {
 		return KubeConfig, nil
 	}

--- a/pkg/env/clusterdiscovery/clusterdiscovery.go
+++ b/pkg/env/clusterdiscovery/clusterdiscovery.go
@@ -13,8 +13,15 @@ import (
 func DiscoverCluster() (string, string, error) {
 	selectedCluster := surveyClusters()
 
+	// set current context to selected cluster for connecting to cluster using client-go
+	api.KubeConfig.CurrentContext = api.ClusterNames[selectedCluster]
+
 	if err := api.CreateK8sClient(selectedCluster); err != nil {
 		return "", "", errors.Wrap(err, "k8s api client failed to create")
+	}
+
+	if err := api.CreateO7tClient(selectedCluster); err != nil {
+		return "", "", errors.Wrap(err, "openshift api client failed to create")
 	}
 
 	clusterNodes, err := queryNodes(api.K8sClient.CoreV1())

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -118,14 +118,19 @@ func surveyMissingValues() error {
 		}
 	}
 
-	if configSource == "Remote host" {
+	switch configSource {
+	case "Remote host":
 		err := surveySSHConfigValues()
 		if err != nil {
 			return err
 		}
 		viperConfig.Set("FetchFromRemote", true)
-	} else {
-
+	case "Local":
+		err := surveyConfigPaths()
+		if err != nil {
+			return err
+		}
+		viperConfig.Set("FetchFromRemote", false)
 	}
 
 	err := createAPIClients()
@@ -268,7 +273,53 @@ func surveyCreateConfigFile() error {
 	return nil
 }
 
-func getOCPConfigSource() error {
+func surveyConfigPaths() error {
+	config := ""
+	prompt := &survey.Input{
+		Message: "Path to crio config file, example: /path/crio/crio.conf",
+	}
+	err := survey.AskOne(prompt, &config, nil)
+	if err != nil {
+		return err
+	}
+	viperConfig.Set("CrioConfigFile", config)
+
+	prompt = &survey.Input{
+		Message: "Path to etcd config file, example: /path/etcd/etcd.conf",
+	}
+	err = survey.AskOne(prompt, &config, nil)
+	if err != nil {
+		return err
+	}
+	viperConfig.Set("ETCDConfigFile", config)
+
+	prompt = &survey.Input{
+		Message: "Path to master config file, example: /path/etcd/master-config.yaml",
+	}
+	err = survey.AskOne(prompt, &config, nil)
+	if err != nil {
+		return err
+	}
+	viperConfig.Set("MasterConfigFile", config)
+
+	prompt = &survey.Input{
+		Message: "Path to node config file, example: /path/node/node-config.yaml",
+	}
+	err = survey.AskOne(prompt, &config, nil)
+	if err != nil {
+		return err
+	}
+	viperConfig.Set("NodeConfigFile", config)
+
+	prompt = &survey.Input{
+		Message: "Path to registries config file, example: /path/containers/registries.conf",
+	}
+	err = survey.AskOne(prompt, &config, nil)
+	if err != nil {
+		return err
+	}
+	viperConfig.Set("RegistriesConfigFile", config)
+
 	return nil
 }
 

--- a/pkg/env/testdata/cpma-config.yml
+++ b/pkg/env/testdata/cpma-config.yml
@@ -6,3 +6,4 @@ SSHCreds:
   Port: 22
 OutputDir: "./data"
 ClusterName: "somename"
+ConfigSource: remote

--- a/pkg/io/io.go
+++ b/pkg/io/io.go
@@ -19,6 +19,19 @@ import (
 // If it fails then connects to Hostname to retrieve file and stores it locally
 // To force a network connection remove outputDir/... prior to exec.
 var FetchFile = func(src string) ([]byte, error) {
+	var f []byte
+	var err error
+
+	if env.Config().GetBool("FetchFromRemote") {
+		f, err = fetchFromRemote(src)
+	} else {
+		f, err = fetchFromLocal(src)
+	}
+
+	return f, err
+}
+
+func fetchFromRemote(src string) ([]byte, error) {
 	dst := filepath.Join(env.Config().GetString("Hostname"), src)
 	f, err := ReadFile(dst)
 	if err != nil {
@@ -47,6 +60,14 @@ var FetchFile = func(src string) ([]byte, error) {
 		}
 		return netFile, nil
 
+	}
+	return f, nil
+}
+
+func fetchFromLocal(src string) ([]byte, error) {
+	f, err := ioutil.ReadFile(src)
+	if err != nil {
+		return nil, err
 	}
 	return f, nil
 }


### PR DESCRIPTION
Closes https://github.com/fusor/cpma/issues/278

If ssh is not available, we ask user for source of config files, local or remote. If remote then we keep them same workflow we have right now, if local then just use survey to get paths listed here.
This PR also adds ability for user to choose how API client should be created, using cluster name from current context or prompt.
 
I will try to add tests for `survey` inputs later and update README after review.


Local files as source:
![local](https://user-images.githubusercontent.com/20123872/60581111-87246a80-9d86-11e9-9400-3ad51520a216.gif)
Remote files:
![remote](https://user-images.githubusercontent.com/20123872/60581251-c0f57100-9d86-11e9-9ab3-7681b840731a.gif)


