### PR TITLE
Usage of list instead of map in requests.go (Refactor)

### DIFF
--- a/pkg/api/requests.go
+++ b/pkg/api/requests.go
@@ -13,13 +13,14 @@ type Resources struct {
 	PersistentVolumeList *k8sapicore.PersistentVolumeList
 	NodeList             *k8sapicore.NodeList
 	StorageClassList     *k8sapistorage.StorageClassList
-	NamespaceMap         map[string]*NamespaceResources
+	NamespaceList        []NamespaceResources
 }
 
 // NamespaceResources holds all resources that belong to a namespace
 type NamespaceResources struct {
-	PodList   *k8sapicore.PodList
-	RouteList *O7tapiroute.RouteList
+	NamespaceName string
+	PodList       *k8sapicore.PodList
+	RouteList     *O7tapiroute.RouteList
 }
 
 var listOptions metav1.ListOptions


### PR DESCRIPTION
Moved from usage of map for `NamespaceResources`, to additional parametr for `NamespaceResources`, describing the name of related namespace. Should be presorted now. Closes #280 and unblocks #252.