### PR TITLE
[WIP] Fix for env variables support in Viper.

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -44,6 +44,10 @@ func Config() *viper.Viper {
 
 // InitConfig initializes application's configuration
 func InitConfig() error {
+	// Fill in environment variables that match
+	viperConfig.SetEnvPrefix("CPMA")
+	viperConfig.AutomaticEnv()
+
 	// Find home directory.
 	home, err := homedir.Dir()
 	if err != nil {
@@ -65,8 +69,6 @@ func InitConfig() error {
 		viperConfig.AddConfigPath(home)
 		viperConfig.SetConfigName("cpma")
 	}
-	// Fill in environment variables that match
-	viper.AutomaticEnv()
 
 	// If a config file is found, read it in.
 	readConfigErr := viperConfig.ReadInConfig()


### PR DESCRIPTION
Added `CPMA` prefix to avoid mess with predefined env variables.

Now it is possible for example to `export CPMA_HOSTNAME=<cluster_hostname>` and not care about feeding those variables manually.

TODO: implications