### PR TITLE
Config arguments rearrangement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 *.swp
 cpma
 cpma.yaml
+**/testdata/out/*
 
 # Standard and 3rd party lib ignored - use go tool to regenerate
 /src/*.*/

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,9 +48,14 @@ func init() {
 	env.Config().BindPFlag("ClusterName", rootCmd.PersistentFlags().Lookup("cluster-name"))
 
 	// Get ssh config values from CLI argument
-	rootCmd.PersistentFlags().StringVarP(&env.Login, "ssh-login", "l", "", "OCP3 ssh login")
-	rootCmd.PersistentFlags().StringVarP(&env.PrivateKey, "ssh-keyfile", "k", "", "OCP3 ssh keyfile path")
-	rootCmd.PersistentFlags().StringVarP(&env.Port, "ssh-port", "p", "", "OCP3 ssh port")
+	rootCmd.PersistentFlags().StringP("ssh-login", "l", "", "OCP3 ssh login")
+	env.Config().BindPFlag("SSHLogin", rootCmd.PersistentFlags().Lookup("ssh-login"))
+
+	rootCmd.PersistentFlags().StringP("ssh-keyfile", "k", "", "OCP3 ssh keyfile path")
+	env.Config().BindPFlag("SSHPrivateKey", rootCmd.PersistentFlags().Lookup("ssh-keyfile"))
+
+	rootCmd.PersistentFlags().StringP("ssh-port", "p", "", "OCP3 ssh port")
+	env.Config().BindPFlag("SSHPort", rootCmd.PersistentFlags().Lookup("ssh-port"))
 
 	// Get config file from CLI argument an save to viper config
 	rootCmd.PersistentFlags().StringP("output-dir", "o", "", "set the directory to store extracted configuration.")

--- a/examples/cpma-config.example.yaml
+++ b/examples/cpma-config.example.yaml
@@ -1,13 +1,18 @@
 ---
-Hostname: "master-0.example.com" # can also point to directory
-SSHCreds:
-  Login: "root"
-  PrivateKey: "/home/example/.ssh/key"
-  Port: 22
-InsecureHostKey: true
-ClusterName: "example-cluster.examle.com"
-OutputDir: "./data"
+clustername: "example-cluster.examle.com"
+configsource: remote
+crioconfigfile: /etc/crio/crio.conf
+etcdconfigfile: /etc/etcd/etcd.conf
+fetchfromremote: true
+home: /home/dgrigore
+hostname: "master-0.example.com"
+insecurehostkey: false
 # MasterConfigFile and NodeConfigFile are optional fields
 # Use only if cluster was configured with different config locations
-MasterConfigFile: "/etc/origin/master/master-config.yaml"
-NodeConfigFile: "/etc/origin/node/node-config.yaml"
+masterconfigfile: /etc/origin/master/master-config.yaml
+nodeconfigfile: /etc/origin/node/node-config.yaml
+outputdir: "./data"
+registriesconfigfile: /etc/containers/registries.conf
+sshlogin: root
+sshport: "22"
+sshprivatekey: "/home/example/.ssh/key"

--- a/pkg/api/initclient.go
+++ b/pkg/api/initclient.go
@@ -40,7 +40,6 @@ func ParseKubeConfig() error {
 	if err != nil {
 		return err
 	}
-
 	// Map context clusters and name for easier access in future
 	for name, context := range KubeConfig.Contexts {
 		ClusterNames[context.Cluster] = name

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -23,12 +23,6 @@ const (
 var (
 	// ConfigFile - keeps full path to the configuration file
 	ConfigFile string
-	// Login ssh login
-	Login string
-	// PrivateKey private key path
-	PrivateKey string
-	// Port ssh port
-	Port string
 
 	viperConfig *viper.Viper
 )
@@ -67,9 +61,6 @@ func InitConfig() error {
 	// If a config file is found, read it in.
 	readConfigErr := viperConfig.ReadInConfig()
 
-	// read all nested values like ssh login, port and key
-	getNestedArgValues()
-
 	// Parse kubeconfig for creating api client later
 	err = api.ParseKubeConfig()
 	if err != nil {
@@ -92,22 +83,6 @@ func InitConfig() error {
 	}
 
 	return nil
-}
-
-func getNestedArgValues() {
-	sshCreds := viperConfig.GetStringMapString("SSHCreds")
-	if Login != "" {
-		sshCreds["login"] = Login
-	}
-
-	if PrivateKey != "" {
-		sshCreds["privatekey"] = PrivateKey
-	}
-
-	if Port != "" {
-		sshCreds["port"] = Port
-	}
-	viperConfig.Set("SSHCreds", sshCreds)
 }
 
 func surveyMissingValues() error {
@@ -178,9 +153,9 @@ func surveyConfigSource() error {
 }
 
 func surveySSHConfigValues() error {
-	if viperConfig.GetString("Hostname") == "" {
+	hostname := viperConfig.GetString("Hostname")
+	if !viperConfig.InConfig("hostname") && hostname == "" {
 		discoverCluster := ""
-		hostname := ""
 		clusterName := ""
 		var err error
 
@@ -213,9 +188,21 @@ func surveySSHConfigValues() error {
 		viperConfig.Set("Hostname", hostname)
 	}
 
-	sshCreds := viperConfig.GetStringMapString("SSHCreds")
-	if sshCreds["login"] == "" {
-		login := ""
+	clusterName := viperConfig.GetString("ClusterName")
+	if !viperConfig.InConfig("clustername") && clusterName == "" {
+		prompt := &survey.Input{
+			Message: "Cluster name",
+		}
+		err := survey.AskOne(prompt, &clusterName, nil)
+		if err != nil {
+			return err
+		}
+
+		viperConfig.Set("ClusterName", clusterName)
+	}
+
+	login := viperConfig.GetString("SSHLogin")
+	if !viperConfig.InConfig("sshlogin") && login == "" {
 		prompt := &survey.Input{
 			Message: "SSH login",
 			Default: "root",
@@ -225,11 +212,11 @@ func surveySSHConfigValues() error {
 			return err
 		}
 
-		sshCreds["login"] = login
+		viperConfig.Set("SSHLogin", login)
 	}
 
-	if sshCreds["port"] == "" {
-		port := ""
+	port := viperConfig.GetString("SSHPort")
+	if !viperConfig.InConfig("sshport") && port == "" {
 		prompt := &survey.Input{
 			Message: "SSH Port",
 			Default: "22",
@@ -239,11 +226,11 @@ func surveySSHConfigValues() error {
 			return err
 		}
 
-		sshCreds["port"] = port
+		viperConfig.Set("SSHPort", port)
 	}
 
-	if sshCreds["privatekey"] == "" {
-		privatekey := ""
+	privatekey := viperConfig.GetString("SSHPrivateKey")
+	if !viperConfig.InConfig("sshprivatekey") && privatekey == "" {
 		prompt := &survey.Input{
 			Message: "Path to private SSH key",
 		}
@@ -252,10 +239,8 @@ func surveySSHConfigValues() error {
 			return err
 		}
 
-		sshCreds["privatekey"] = privatekey
+		viperConfig.Set("SSHPrivateKey", privatekey)
 	}
-
-	viperConfig.Set("SSHCreds", sshCreds)
 
 	// set defaults for remote config files paths
 	viperConfig.SetDefault("CrioConfigFile", "/etc/crio/crio.conf")
@@ -267,8 +252,9 @@ func surveySSHConfigValues() error {
 }
 
 func surveyConfigPaths() error {
-	config := ""
-	if viperConfig.GetString("CrioConfigFile") == "" && !viperConfig.InConfig("crioconfigfile") {
+	var config string
+	config = viperConfig.GetString("CrioConfigFile")
+	if !viperConfig.InConfig("crioconfigfile") && config == "" {
 		prompt := &survey.Input{
 			Message: "Path to crio config file, example: /path/crio/crio.conf",
 		}
@@ -279,7 +265,8 @@ func surveyConfigPaths() error {
 		viperConfig.Set("CrioConfigFile", config)
 	}
 
-	if viperConfig.GetString("ETCDConfigFile") == "" && !viperConfig.InConfig("etcdconfigfile") {
+	config = viperConfig.GetString("ETCDConfigFile")
+	if !viperConfig.InConfig("etcdconfigfile") && config == "" {
 		prompt := &survey.Input{
 			Message: "Path to etcd config file, example: /path/etcd/etcd.conf",
 		}
@@ -290,7 +277,8 @@ func surveyConfigPaths() error {
 		viperConfig.Set("ETCDConfigFile", config)
 	}
 
-	if viperConfig.GetString("MasterConfigFile") == "" && !viperConfig.InConfig("masterconfigfile") {
+	config = viperConfig.GetString("MasterConfigFile")
+	if !viperConfig.InConfig("masterconfigfile") && config == "" {
 		prompt := &survey.Input{
 			Message: "Path to master config file, example: /path/etcd/master-config.yaml",
 		}
@@ -301,7 +289,8 @@ func surveyConfigPaths() error {
 		viperConfig.Set("MasterConfigFile", config)
 	}
 
-	if viperConfig.GetString("NodeConfigFile") == "" && !viperConfig.InConfig("nodeconfigfile") {
+	config = viperConfig.GetString("NodeConfigFile")
+	if !viperConfig.InConfig("nodeconfigfile") && config == "" {
 		prompt := &survey.Input{
 			Message: "Path to node config file, example: /path/node/node-config.yaml",
 		}
@@ -312,7 +301,8 @@ func surveyConfigPaths() error {
 		viperConfig.Set("NodeConfigFile", config)
 	}
 
-	if viperConfig.GetString("RegistriesConfigFile") == "" && !viperConfig.InConfig("registriesconfigfile") {
+	config = viperConfig.GetString("RegistriesConfigFile")
+	if !viperConfig.InConfig("registriesconfigfile") && config == "" {
 		prompt := &survey.Input{
 			Message: "Path to registries config file, example: /path/containers/registries.conf",
 		}
@@ -380,14 +370,18 @@ func createAPIClients() error {
 }
 
 func surveyCreateConfigFile() error {
-	createConfig := ""
-	prompt := &survey.Select{
-		Message: "No config file found, do you wish to create one for future use?",
-		Options: []string{"yes", "no"},
-	}
-	err := survey.AskOne(prompt, &createConfig, nil)
-	if err != nil {
-		return err
+	createConfig := viperConfig.GetString("CreateConfig")
+	if createConfig == "" {
+		prompt := &survey.Select{
+			Message: "No config file found, do you wish to create one for future use?",
+			Options: []string{"yes", "no"},
+		}
+		err := survey.AskOne(prompt, &createConfig, nil)
+		if err != nil {
+			return err
+		}
+		viperConfig.Set("CreateConfig", createConfig)
+
 	}
 
 	if createConfig == "yes" {

--- a/pkg/env/testdata/cpma-config.yml
+++ b/pkg/env/testdata/cpma-config.yml
@@ -1,4 +1,3 @@
----
 hostname: "master-0.test.example.com"
 sshlogin: "root"
 sshprivatekey: "/home/test/.ssh/testkey"

--- a/pkg/env/testdata/cpma-config.yml
+++ b/pkg/env/testdata/cpma-config.yml
@@ -1,9 +1,8 @@
 ---
-Hostname: "master-0.test.example.com"
-SSHCreds:
-  Login: "root"
-  PrivateKey: "/home/test/.ssh/testkey"
-  Port: 22
-OutputDir: "./data"
-ClusterName: "somename"
-ConfigSource: remote
+hostname: "master-0.test.example.com"
+sshlogin: "root"
+sshprivatekey: "/home/test/.ssh/testkey"
+sshport: 22
+outputdir: "./data"
+clustername: "somename"
+configsource: remote

--- a/pkg/io/remotehost/remotehost.go
+++ b/pkg/io/remotehost/remotehost.go
@@ -32,11 +32,9 @@ type Client struct {
 
 // CreateConnection create ssh connection
 func CreateConnection(source string) (*ssh.Client, error) {
-	sshCreds := env.Config().GetStringMapString("SSHCreds")
-
-	key, err := ioutil.ReadFile(sshCreds["privatekey"])
+	key, err := ioutil.ReadFile(env.Config().GetString("SSHPrivateKey"))
 	if err != nil {
-		return nil, errors.Wrapf(err, "Unable to read private key: %s\n", sshCreds["privatekey"])
+		return nil, errors.Wrapf(err, "Unable to read private key: %s\n", key)
 	}
 
 	// Create the Signer for this private key.
@@ -58,7 +56,7 @@ func CreateConnection(source string) (*ssh.Client, error) {
 	}
 
 	sshConfig := &ssh.ClientConfig{
-		User: sshCreds["login"],
+		User: env.Config().GetString("SSHLogin"),
 		Auth: []ssh.AuthMethod{
 			ssh.PublicKeys(signer),
 		},
@@ -68,7 +66,7 @@ func CreateConnection(source string) (*ssh.Client, error) {
 	}
 
 	port := 22
-	if p := sshCreds["port"]; p != "" {
+	if p := env.Config().GetString("SSHPort"); p != "" {
 		port, err = strconv.Atoi(p)
 		if err != nil || port < 1 || port > 65535 {
 			return nil, errors.Wrapf(err, "Port number %s is wrong\n", p)


### PR DESCRIPTION
- Fixed logic in retrival of config variables.
- Removed nested ssh values.
- Now every variable from config could be defined as following.

| ENV variable               | Config equivalent    |
|----------------------------|----------------------|
| CPMA_CLUSTERNAME           | clustername          |
| CPMA_SSHPORT               | sshport              |
| CPMA_CREATECONFIG          | createconfig         |
| CPMA_OUTPUTDIR             | outputdir            |
| CPMA_SSHPRIVATEKEY         | sshprivatekey        |
| CPMA_LOGIN                 | login                |
| CPMA_CONFIGSOURCE          | configsource         |
| CPMA_PASSWD                | passwd               |
| CPMA_HOSTNAME              | hostname             |
| CPMA_SSHLOGIN              | sshlogin             |
| CPMA_CRIOCONFIGFILE        | crioconfigfile       |
| CPMA_ETCDCONFIGFILE        | etcdconfigfile       |
| CPMA_REGISTRIESCONFIGFILE  | registriesconfigfile |
| CPMA_HOME                  | home                 |
| CPMA_MASTERCONFIGFILE      | masterconfigfile     |
| CPMA_NODECONFIGFILE        | nodeconfigfile       |

Other environment variables:

| ENV variable               |  Description      				 |
|----------------------------|---------------------------------------------------|
| CPMA_CREATECONFIG          |  Enables or disables authomatic config creation   |

Other changes:

Removed nested ssh variables
```
SSHCreds:
  Login: "root"
  PrivateKey: "/home/example/.ssh/key"
  Port: 22
```
substituted with
```
sshlogin: root
sshport: "22"
sshprivatekey: "/home/example/.ssh/key"
```