### PR TITLE
Local feature use OutputDir for application working dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Flags:
   -l, --login string        OCP3 ssh login
   -p, --port string         OCP3 ssh port
   -s, --source string       OCP3 cluster hostname
-  -w, --work-dir string     set the working directory (default ".")
+  -w, --work-dir string     set application data working directory (Default ".")
 ```
 
 ## IO

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Flags:
   -d, --debug                 show debug ouput
   -h, --help                  help for cpma
   -n, --hostname string       OCP3 cluster hostname
-  -o, --output-dir string     set the directory to store extracted configuration. (default ".")
+  -w, --work-dir string       set the working directory (default ".")
   -k, --ssh-keyfile string    OCP3 ssh keyfile path
   -l, --ssh-login string      OCP3 ssh login
   -p, --ssh-port string       OCP3 ssh port
@@ -50,7 +50,7 @@ docker run -it --rm -v ${PWD}:/mnt:z -v $HOME/.kube:/.kube:z -v $HOME/.ssh:/.ssh
 quay.io/ocpmigrate/cpma:latest
 ```
 
-In these examples `${PWD}` is mounted in the working directory of the image (`/mnt`). This means that paths provided to --config and --output-dir will need to specified be relative to your present working directory.
+In these examples `${PWD}` is mounted in the working directory of the image (`/mnt`). This means that paths provided to --config and --work-dir will need to specified be relative to your present working directory.
 
 To make it a little more intuitive it can also be run via an alias, for example:
 ```
@@ -71,9 +71,9 @@ Flags:
       --insecure-key        allow insecure host key
   -k, --key string          OCP3 ssh key path
   -l, --login string        OCP3 ssh login
-  -o, --output-dir string   set the directory to store extracted configuration. (default ".")
   -p, --port string         OCP3 ssh port
   -s, --source string       OCP3 cluster hostname
+  -w, --work-dir string     set the working directory (default ".")
 ```
 
 ## IO
@@ -98,7 +98,7 @@ data
                 └── node-config.yaml
 ```
 
-The configuration files are retrieved from local disk (`outputDir/<Hostname>/`),
+The configuration files are retrieved from local disk (`workDir/<Hostname>/`),
 If a file is not available it's retrieved from `<Hostname>` and stored on local disk.
 
 To trigger a total or partial network file fetch, remove any prior data from

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,7 +58,7 @@ func init() {
 	env.Config().BindPFlag("SSHPort", rootCmd.PersistentFlags().Lookup("ssh-port"))
 
 	// Get config file from CLI argument an save to viper config
-	rootCmd.PersistentFlags().StringP("work-dir", "w", "", "set the working directory")
+	rootCmd.PersistentFlags().StringP("work-dir", "w", "", "set application data working directory (Default \".\")")
 	env.Config().BindPFlag("WorkDir", rootCmd.PersistentFlags().Lookup("work-dir"))
 
 	// Set log level from CLI argument

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,8 +58,8 @@ func init() {
 	env.Config().BindPFlag("SSHPort", rootCmd.PersistentFlags().Lookup("ssh-port"))
 
 	// Get config file from CLI argument an save to viper config
-	rootCmd.PersistentFlags().StringP("output-dir", "o", "", "set the directory to store extracted configuration.")
-	env.Config().BindPFlag("OutputDir", rootCmd.PersistentFlags().Lookup("output-dir"))
+	rootCmd.PersistentFlags().StringP("work-dir", "w", "", "set the working directory")
+	env.Config().BindPFlag("WorkDir", rootCmd.PersistentFlags().Lookup("work-dir"))
 
 	// Set log level from CLI argument
 	rootCmd.PersistentFlags().String("config-source", "", "source for OCP3 config files, accepted values: remote or local")

--- a/examples/cpma-config.example.yaml
+++ b/examples/cpma-config.example.yaml
@@ -11,7 +11,7 @@ insecurehostkey: false
 # Use only if cluster was configured with different config locations
 masterconfigfile: /etc/origin/master/master-config.yaml
 nodeconfigfile: /etc/origin/node/node-config.yaml
-outputdir: "./data"
+workdir: "./data"
 registriesconfigfile: /etc/containers/registries.conf
 sshlogin: root
 sshport: "22"

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -119,18 +119,18 @@ func surveyMissingValues() error {
 		return err
 	}
 
-	if viperConfig.GetString("OutputDir") == "" {
-		outputDir := "."
+	if viperConfig.GetString("WorkDir") == "" {
+		workDir := "."
 		prompt := &survey.Input{
-			Message: "Path to output, skip to use current directory",
+			Message: "Path to work, skip to use current directory",
 			Default: ".",
 		}
-		err := survey.AskOne(prompt, &outputDir, nil)
+		err := survey.AskOne(prompt, &workDir, nil)
 		if err != nil {
 			return err
 		}
 
-		viperConfig.Set("OutputDir", outputDir)
+		viperConfig.Set("WorkDir", workDir)
 	}
 
 	return nil

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -122,7 +122,7 @@ func surveyMissingValues() error {
 	if viperConfig.GetString("WorkDir") == "" {
 		workDir := "."
 		prompt := &survey.Input{
-			Message: "Path to work, skip to use current directory",
+			Message: "Path to application data, skip to use current directory",
 			Default: ".",
 		}
 		err := survey.AskOne(prompt, &workDir, nil)

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -57,7 +57,7 @@ func TestInitFromEnv(t *testing.T) {
 	}
 	var err error
 
-	outputDir := "testdata/out"
+	workDir := "testdata/out"
 	testCases := []struct {
 		name         string
 		sourceConfig []configAsset
@@ -133,7 +133,7 @@ func TestInitFromEnv(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			os.Setenv("CPMA_CREATECONFIG", "yes")
 			os.Setenv("CPMA_CLUSTERNAME", "somename")
-			os.Setenv("CPMA_OUTPUTDIR", outputDir)
+			os.Setenv("CPMA_WORKDIR", workDir)
 			api.K8sClient = &kubernetes.Clientset{}
 			api.O7tClient = &api.OpenshiftClient{}
 			for _, asset := range tc.sourceConfig {

--- a/pkg/env/testdata/cpma-config.yml
+++ b/pkg/env/testdata/cpma-config.yml
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 hostname: "master-0.test.example.com"
 sshlogin: "root"
 sshprivatekey: "/home/test/.ssh/testkey"
@@ -6,4 +5,3 @@ sshport: 22
 workdir: "./data"
 clustername: "somename"
 configsource: remote
->>>>>>> Local option to work from working dir

--- a/pkg/env/testdata/cpma-config.yml
+++ b/pkg/env/testdata/cpma-config.yml
@@ -1,7 +1,9 @@
+<<<<<<< HEAD
 hostname: "master-0.test.example.com"
 sshlogin: "root"
 sshprivatekey: "/home/test/.ssh/testkey"
 sshport: 22
-outputdir: "./data"
+workdir: "./data"
 clustername: "somename"
 configsource: remote
+>>>>>>> Local option to work from working dir

--- a/pkg/io/io.go
+++ b/pkg/io/io.go
@@ -60,7 +60,7 @@ func fetchFromRemote(src string) ([]byte, error) {
 }
 
 func fetchFromLocal(src string) ([]byte, error) {
-	localSrc := filepath.Join(env.Config().GetString("WorkDir"), env.Config().GetString("Source"), src)
+	localSrc := filepath.Join(env.Config().GetString("WorkDir"), env.Config().GetString("Hostname"), src)
 	f, err := ioutil.ReadFile(localSrc)
 	if err != nil {
 		return nil, err

--- a/pkg/io/io.go
+++ b/pkg/io/io.go
@@ -15,9 +15,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// FetchFile first tries to retrieve file from local disk (outputDir/<Hostname>/).
+// FetchFile first tries to retrieve file from local disk (workDir/<Hostname>/).
 // If it fails then connects to Hostname to retrieve file and stores it locally
-// To force a network connection remove outputDir/... prior to exec.
+// To force a network connection remove workDir/... prior to exec.
 var FetchFile = func(src string) ([]byte, error) {
 	var f []byte
 	var err error
@@ -60,7 +60,8 @@ func fetchFromRemote(src string) ([]byte, error) {
 }
 
 func fetchFromLocal(src string) ([]byte, error) {
-	f, err := ioutil.ReadFile(src)
+	localSrc := filepath.Join(env.Config().GetString("WorkDir"), env.Config().GetString("Source"), src)
+	f, err := ioutil.ReadFile(localSrc)
 	if err != nil {
 		return nil, err
 	}
@@ -107,15 +108,15 @@ func FetchStringSource(stringSource legacyconfigv1.StringSource) (string, error)
 	return "", nil
 }
 
-// ReadFile reads a file in OutputDir and returns its contents
+// ReadFile reads a file in WorkDir and returns its contents
 func ReadFile(file string) ([]byte, error) {
-	src := filepath.Join(env.Config().GetString("OutputDir"), file)
+	src := filepath.Join(env.Config().GetString("WorkDir"), file)
 	return ioutil.ReadFile(src)
 }
 
-// WriteFile writes data to a file in OutputDir
+// WriteFile writes data to a file in WorkDir
 func WriteFile(content []byte, file string) error {
-	dst := filepath.Join(env.Config().GetString("OutputDir"), file)
+	dst := filepath.Join(env.Config().GetString("WorkDir"), file)
 	os.MkdirAll(path.Dir(dst), 0750)
 	return ioutil.WriteFile(dst, content, 0640)
 }

--- a/pkg/transform/manifest_output.go
+++ b/pkg/transform/manifest_output.go
@@ -30,7 +30,7 @@ func (m ManifestOutput) Flush() error {
 // DumpManifests creates OCDs files
 func DumpManifests(manifests []Manifest) {
 	for _, manifest := range manifests {
-		maniftestfile := filepath.Join(env.Config().GetString("OutputDir"), "manifests", manifest.Name)
+		maniftestfile := filepath.Join(env.Config().GetString("WorkDir"), "manifests", manifest.Name)
 		os.MkdirAll(path.Dir(maniftestfile), 0755)
 		err := ioutil.WriteFile(maniftestfile, manifest.CRD, 0644)
 		logrus.Printf("CRD:Added: %s", maniftestfile)


### PR DESCRIPTION
This also renames "OutputDir" to "WorkDir".

`WorDir` is the base when working in `Local` mode in which case files will be searched under the `hostname`.