### PR TITLE
Test for io pkg

### DIFF
--- a/pkg/io/io.go
+++ b/pkg/io/io.go
@@ -33,35 +33,30 @@ var FetchFile = func(src string) ([]byte, error) {
 
 func fetchFromRemote(src string) ([]byte, error) {
 	dst := filepath.Join(env.Config().GetString("Hostname"), src)
-	f, err := ReadFile(dst)
+	host := env.Config().GetString("Hostname")
+
+	cmd := fmt.Sprintf("sudo cat %s", src)
+	output, err := remotehost.RunCMD(host, cmd)
 	if err != nil {
-		host := env.Config().GetString("Hostname")
-
-		cmd := fmt.Sprintf("sudo cat %s", src)
-		output, err := remotehost.RunCMD(host, cmd)
-		if err != nil {
-			return nil, err
-		}
-
-		if output == "" {
-			msg := fmt.Sprintf("Empty or missing file: %s", dst)
-			return nil, errors.New(msg)
-		}
-
-		err = WriteFile([]byte(output), dst)
-		if err != nil {
-			logrus.Errorf("Unable to save: %s", dst)
-			return nil, err
-		}
-
-		netFile, err := ReadFile(dst)
-		if err != nil {
-			return nil, err
-		}
-		return netFile, nil
-
+		return nil, err
 	}
-	return f, nil
+
+	if output == "" {
+		msg := fmt.Sprintf("Empty or missing file: %s", dst)
+		return nil, errors.New(msg)
+	}
+
+	err = WriteFile([]byte(output), dst)
+	if err != nil {
+		logrus.Errorf("Unable to save: %s", dst)
+		return nil, err
+	}
+
+	netFile, err := ReadFile(dst)
+	if err != nil {
+		return nil, err
+	}
+	return netFile, nil
 }
 
 func fetchFromLocal(src string) ([]byte, error) {

--- a/pkg/io/io.go
+++ b/pkg/io/io.go
@@ -32,8 +32,8 @@ var FetchFile = func(src string) ([]byte, error) {
 }
 
 func fetchFromRemote(src string) ([]byte, error) {
-	dst := filepath.Join(env.Config().GetString("Hostname"), src)
 	host := env.Config().GetString("Hostname")
+	dst := filepath.Join(host, src)
 
 	cmd := fmt.Sprintf("sudo cat %s", src)
 	output, err := remotehost.RunCMD(host, cmd)

--- a/pkg/io/io_test.go
+++ b/pkg/io/io_test.go
@@ -1,0 +1,111 @@
+package io
+
+import (
+	"testing"
+
+	"github.com/fusor/cpma/pkg/env"
+	"github.com/fusor/cpma/pkg/io/remotehost"
+	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Save before overriding
+var _RunCMD = remotehost.RunCMD
+
+// Overriding
+func mockRunCMD(hostname, cmd string) (string, error) {
+	return "remote value", nil
+}
+
+func TestFetchFile(t *testing.T) {
+	testCases := []struct {
+		name     string
+		remote   bool
+		expected []byte
+		filename string
+	}{
+		{
+			name:     "Fetch from remote",
+			remote:   true,
+			filename: "remote-file",
+			expected: []byte{0x72, 0x65, 0x6d, 0x6f, 0x74, 0x65, 0x20, 0x76, 0x61, 0x6c, 0x75, 0x65},
+		},
+		{
+			name:     "Fetch from local",
+			remote:   false,
+			filename: "testdata/local-file",
+			expected: []byte{0x6c, 0x6f, 0x63, 0x61, 0x6c, 0x20, 0x76, 0x61, 0x6c, 0x75, 0x65, 0xa},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			env.Config().Set("FetchFromRemote", tc.remote)
+			if tc.remote {
+				defer func() { remotehost.RunCMD = _RunCMD }()
+				remotehost.RunCMD = mockRunCMD
+
+				f, err := FetchFile(tc.filename)
+				require.NoError(t, err)
+				assert.Equal(t, f, tc.expected)
+			} else {
+				f, err := FetchFile(tc.filename)
+				require.NoError(t, err)
+				assert.Equal(t, f, tc.expected)
+			}
+		})
+	}
+}
+
+func TestFetchEnv(t *testing.T) {
+	testCases := []struct {
+		name     string
+		host     string
+		env      string
+		expected string
+	}{
+		{
+			name:     "Fetch remote ENV variable",
+			host:     "remote.test.com",
+			env:      "CPMA_TEST_ENV",
+			expected: "remote value",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() { remotehost.RunCMD = _RunCMD }()
+			remotehost.RunCMD = mockRunCMD
+
+			env, err := FetchEnv(tc.host, tc.env)
+			require.NoError(t, err)
+			assert.Equal(t, env, tc.expected)
+		})
+	}
+}
+
+func TestStringSource(t *testing.T) {
+	testCases := []struct {
+		name     string
+		filename string
+		expected string
+	}{
+		{
+			name:     "Fetch String Source ENV variable",
+			filename: "testdata/local-file",
+			expected: "local value",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			env.Config().Set("FetchFromRemote", false)
+			stringSource := legacyconfigv1.StringSource{}
+			stringSource.File = "testdata/local-file"
+			f, err := FetchStringSource(stringSource)
+			require.NoError(t, err)
+			assert.Equal(t, f, tc.expected)
+		})
+	}
+}

--- a/pkg/io/io_test.go
+++ b/pkg/io/io_test.go
@@ -22,20 +22,20 @@ func TestFetchFile(t *testing.T) {
 	testCases := []struct {
 		name     string
 		remote   bool
-		expected []byte
+		expected string
 		filename string
 	}{
 		{
 			name:     "Fetch from remote",
 			remote:   true,
 			filename: "remote-file",
-			expected: []byte{0x72, 0x65, 0x6d, 0x6f, 0x74, 0x65, 0x20, 0x76, 0x61, 0x6c, 0x75, 0x65},
+			expected: "remote value",
 		},
 		{
 			name:     "Fetch from local",
 			remote:   false,
 			filename: "testdata/local-file",
-			expected: []byte{0x6c, 0x6f, 0x63, 0x61, 0x6c, 0x20, 0x76, 0x61, 0x6c, 0x75, 0x65, 0xa},
+			expected: "local value\n",
 		},
 	}
 
@@ -48,11 +48,11 @@ func TestFetchFile(t *testing.T) {
 
 				f, err := FetchFile(tc.filename)
 				require.NoError(t, err)
-				assert.Equal(t, f, tc.expected)
+				assert.Equal(t, f, []byte(tc.expected))
 			} else {
 				f, err := FetchFile(tc.filename)
 				require.NoError(t, err)
-				assert.Equal(t, f, tc.expected)
+				assert.Equal(t, f, []byte(tc.expected))
 			}
 		})
 	}
@@ -92,7 +92,7 @@ func TestStringSource(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "Fetch String Source ENV variable",
+			name:     "Fetch String Source from value",
 			filename: "testdata/local-file",
 			expected: "local value",
 		},

--- a/pkg/io/remotehost/remotehost.go
+++ b/pkg/io/remotehost/remotehost.go
@@ -92,7 +92,7 @@ func NewSSHSession(source string) (*ssh.Session, error) {
 }
 
 // RunCMD execute cmd on remote host
-func RunCMD(hostname, cmd string) (string, error) {
+var RunCMD = func(hostname, cmd string) (string, error) {
 	session, err := NewSSHSession(hostname)
 	if err != nil {
 		return "", err

--- a/pkg/io/testdata/local-file
+++ b/pkg/io/testdata/local-file
@@ -1,0 +1,1 @@
+local value


### PR DESCRIPTION
Adds tests to cover FetchFile(fetchFromRemote and FetchFromLocal), FetchEnv and FetchStringSource

Also refactored fetchFromRemote which was (historically) fetching file from local first. This is not needed anymore since fetchFromLocal is used by FetchFile.