### PR TITLE
Add TestMain

### DIFF
--- a/cpma_test.go
+++ b/cpma_test.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
There isn't much to test in main package, meanwhile `TestMain` (since go 1.4 [1]) allows to setup environment if needed. This might be handy for CI.

[1] https://justinas.org/my-reason-to-be-excited-for-go-14