### PR TITLE
Add warn log level to error hook

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -441,7 +441,6 @@ func InitLogger() {
 			LogLevels: []logrus.Level{
 				logrus.InfoLevel,
 				logrus.DebugLevel,
-				logrus.WarnLevel,
 			},
 			Formatter: consoleFormatter,
 		}
@@ -455,6 +454,7 @@ func InitLogger() {
 			logrus.PanicLevel,
 			logrus.FatalLevel,
 			logrus.ErrorLevel,
+			logrus.WarnLevel,
 		},
 		Formatter: consoleFormatter,
 	}

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -183,6 +183,7 @@ func TestInitLogger(t *testing.T) {
 			logrus.PanicLevel,
 			logrus.FatalLevel,
 			logrus.ErrorLevel,
+			logrus.WarnLevel,
 		},
 		Formatter: consoleFormatter,
 	}
@@ -192,7 +193,6 @@ func TestInitLogger(t *testing.T) {
 		LogLevels: []logrus.Level{
 			logrus.InfoLevel,
 			logrus.DebugLevel,
-			logrus.WarnLevel,
 		},
 		Formatter: consoleFormatter,
 	}


### PR DESCRIPTION
Having warn log level in error hook will be useful. This way connections timeouts or info about skipped report/translate parts will be visible by default.

Closes https://github.com/fusor/cpma/issues/270