### PR TITLE
Make generation of manifests and report optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,24 @@ $ ./bin/cpma
 
 Flags:
 ```
-  -i, --allow-insecure-host   allow insecure ssh host key
-  -c, --cluster-name string   OCP3 cluster kubeconfig name
-      --config string         config file (Default searches ./cpma.yaml, $HOME/cpma.yml)
-  -d, --debug                 show debug ouput
-  -h, --help                  help for cpma
-  -n, --hostname string       OCP3 cluster hostname
-  -w, --work-dir string       set the working directory (default ".")
-  -k, --ssh-keyfile string    OCP3 ssh keyfile path
-  -l, --ssh-login string      OCP3 ssh login
-  -p, --ssh-port string       OCP3 ssh port
-  -v, --verbose               verbose output
+  -i, --allow-insecure-host        allow insecure ssh host key
+  -c, --cluster-name string        OCP3 cluster kubeconfig name
+      --config string              config file (Default searches ./cpma.yaml, $HOME/cpma.yml)
+      --config-source string       source for OCP3 config files, accepted values: remote or local
+      --crio-config string         path to crio config file
+  -d, --debug                      show debug ouput
+      --etcd-config string         path to etcd config file
+  -h, --help                       help for cpma
+  -n, --hostname string            OCP3 cluster hostname
+      --master-config string       path to master config file
+      --mode string                Set CPMA mode: generate only report, only manifests or both. Accepted values: manifests or report
+      --node-config string         path to node config file
+      --registries-config string   path to registries config file
+  -k, --ssh-keyfile string         OCP3 ssh keyfile path
+  -l, --ssh-login string           OCP3 ssh login
+  -p, --ssh-port string            OCP3 ssh port
+  -v, --verbose                    verbose output
+  -w, --work-dir string            set application data working directory (Default ".")
 ```
 
 You can find an example config in `examples/`. If a config is not provided CPMA will prompt for configuration information and offer to save inputs to a new configuration file.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,9 +61,13 @@ func init() {
 	rootCmd.PersistentFlags().StringP("work-dir", "w", "", "set application data working directory (Default \".\")")
 	env.Config().BindPFlag("WorkDir", rootCmd.PersistentFlags().Lookup("work-dir"))
 
-	// Set log level from CLI argument
+	// Set config source from CLI argument
 	rootCmd.PersistentFlags().String("config-source", "", "source for OCP3 config files, accepted values: remote or local")
 	env.Config().BindPFlag("ConfigSource", rootCmd.PersistentFlags().Lookup("config-source"))
+
+	// Set cpma mode level from CLI argument
+	rootCmd.PersistentFlags().String("mode", "", "Set CPMA mode: generate only report, only manifests or both. Accepted values: manifests or report")
+	env.Config().BindPFlag("Mode", rootCmd.PersistentFlags().Lookup("mode"))
 
 	// Get crio config file location
 	rootCmd.PersistentFlags().String("crio-config", "", "path to crio config file")

--- a/examples/cpma-config.example.yaml
+++ b/examples/cpma-config.example.yaml
@@ -16,3 +16,4 @@ registriesconfigfile: /etc/containers/registries.conf
 sshlogin: root
 sshport: "22"
 sshprivatekey: "/home/example/.ssh/key"
+mode: report

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -19,6 +19,11 @@ const (
 	// AppName holds the name of this application
 	AppName = "CPMA"
 	logFile = "cpma.log"
+
+	// OnlyReportMode holds name of cpma mode
+	OnlyReportMode = "OnlyReportMode"
+	// OnlyManifestMode holds name of cpma mode
+	OnlyManifestMode = "OnlyManifestMode"
 )
 
 var (

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -90,6 +90,11 @@ func TestInitFromEnv(t *testing.T) {
 					envValue:         "remote",
 					configEquivalent: "configsource",
 				},
+				configAsset{
+					envKey:           "CPMA_MODE",
+					envValue:         "report",
+					configEquivalent: "mode",
+				},
 			},
 		},
 		{
@@ -124,6 +129,11 @@ func TestInitFromEnv(t *testing.T) {
 					envKey:           "CPMA_REGISTRIESCONFIGFILE",
 					envValue:         "test-registries",
 					configEquivalent: "registriesconfigfile",
+				},
+				configAsset{
+					envKey:           "CPMA_MODE",
+					envValue:         "report",
+					configEquivalent: "mode",
 				},
 			},
 		},

--- a/pkg/env/testdata/cpma-config.yml
+++ b/pkg/env/testdata/cpma-config.yml
@@ -5,3 +5,4 @@ sshport: 22
 workdir: "./data"
 clustername: "somename"
 configsource: remote
+mode: ""

--- a/pkg/transform/api_transform.go
+++ b/pkg/transform/api_transform.go
@@ -40,7 +40,7 @@ func (e APIExtraction) Transform() ([]Output, error) {
 }
 
 func (e APIExtraction) buildReportOutput() (Output, error) {
-	if env.Config().GetString("Mode") == env.OnlyManifestMode {
+	if env.Config().GetString("Mode") == env.OnlyManifestsMode {
 		logrus.Debug("Skipping APITransform report, only manifest mode was set")
 		return ReportOutput{}, nil
 	}

--- a/pkg/transform/api_transform.go
+++ b/pkg/transform/api_transform.go
@@ -40,6 +40,11 @@ func (e APIExtraction) Transform() ([]Output, error) {
 }
 
 func (e APIExtraction) buildReportOutput() (Output, error) {
+	if env.Config().GetString("Mode") == env.OnlyManifestMode {
+		logrus.Debug("Skipping APITransform report, only manifest mode was set")
+		return ReportOutput{}, nil
+	}
+
 	componentReport := ComponentReport{
 		Component: APIComponentName,
 	}

--- a/pkg/transform/cluster_report_transform.go
+++ b/pkg/transform/cluster_report_transform.go
@@ -23,7 +23,7 @@ type ClusterTransform struct {
 func (e ClusterReportExtraction) Transform() ([]Output, error) {
 	logrus.Info("ClusterTransform::Transform")
 
-	if env.Config().GetString("Mode") == env.OnlyManifestMode {
+	if env.Config().GetString("Mode") == env.OnlyManifestsMode {
 		logrus.Debug("Skipping ClusterTransform report, only manifest mode was set")
 		return []Output{}, nil
 	}

--- a/pkg/transform/cluster_report_transform.go
+++ b/pkg/transform/cluster_report_transform.go
@@ -2,6 +2,7 @@ package transform
 
 import (
 	"github.com/fusor/cpma/pkg/api"
+	"github.com/fusor/cpma/pkg/env"
 	"github.com/fusor/cpma/pkg/transform/cluster"
 	"github.com/sirupsen/logrus"
 )
@@ -21,6 +22,11 @@ type ClusterTransform struct {
 // Transform converts data collected from an OCP3 API into a useful output
 func (e ClusterReportExtraction) Transform() ([]Output, error) {
 	logrus.Info("ClusterTransform::Transform")
+
+	if env.Config().GetString("Mode") == env.OnlyManifestMode {
+		logrus.Debug("Skipping ClusterTransform report, only manifest mode was set")
+		return []Output{}, nil
+	}
 
 	clusterReport := cluster.GenClusterReport(api.Resources{
 		PersistentVolumeList: e.PersistentVolumeList,

--- a/pkg/transform/crio_transform.go
+++ b/pkg/transform/crio_transform.go
@@ -121,7 +121,7 @@ func (e CrioExtraction) buildManifestOutput() (Output, error) {
 }
 
 func (e CrioExtraction) buildReportOutput() (Output, error) {
-	if env.Config().GetString("Mode") == env.OnlyManifestMode {
+	if env.Config().GetString("Mode") == env.OnlyManifestsMode {
 		logrus.Debug("Skipping CrioTransform report, only manifests mode was set")
 		return ReportOutput{}, nil
 	}

--- a/pkg/transform/crio_transform.go
+++ b/pkg/transform/crio_transform.go
@@ -82,6 +82,11 @@ func (e CrioExtraction) Transform() ([]Output, error) {
 }
 
 func (e CrioExtraction) buildManifestOutput() (Output, error) {
+	if env.Config().GetString("Mode") == env.OnlyReportMode {
+		logrus.Debug("Skipping CrioTransform manifests, only report mode was set")
+		return ReportOutput{}, nil
+	}
+
 	var manifests []Manifest
 
 	const (
@@ -116,6 +121,11 @@ func (e CrioExtraction) buildManifestOutput() (Output, error) {
 }
 
 func (e CrioExtraction) buildReportOutput() (Output, error) {
+	if env.Config().GetString("Mode") == env.OnlyManifestMode {
+		logrus.Debug("Skipping CrioTransform report, only manifests mode was set")
+		return ReportOutput{}, nil
+	}
+
 	componentReport := ComponentReport{
 		Component: CrioComponentName,
 	}

--- a/pkg/transform/docker_transform.go
+++ b/pkg/transform/docker_transform.go
@@ -29,6 +29,11 @@ func (e DockerExtraction) Transform() ([]Output, error) {
 }
 
 func (e DockerExtraction) buildReportOutput() (Output, error) {
+	if env.Config().GetString("Mode") == env.OnlyManifestMode {
+		logrus.Debug("Skipping DockerTransform report, only manifests mode was set")
+		return ReportOutput{}, nil
+	}
+
 	componentReport := ComponentReport{
 		Component: DockerComponentName,
 	}

--- a/pkg/transform/docker_transform.go
+++ b/pkg/transform/docker_transform.go
@@ -29,7 +29,7 @@ func (e DockerExtraction) Transform() ([]Output, error) {
 }
 
 func (e DockerExtraction) buildReportOutput() (Output, error) {
-	if env.Config().GetString("Mode") == env.OnlyManifestMode {
+	if env.Config().GetString("Mode") == env.OnlyManifestsMode {
 		logrus.Debug("Skipping DockerTransform report, only manifests mode was set")
 		return ReportOutput{}, nil
 	}

--- a/pkg/transform/etcd_transform.go
+++ b/pkg/transform/etcd_transform.go
@@ -37,7 +37,7 @@ func (e ETCDExtraction) Transform() ([]Output, error) {
 }
 
 func (e ETCDExtraction) buildReportOutput() (Output, error) {
-	if env.Config().GetString("Mode") == env.OnlyManifestMode {
+	if env.Config().GetString("Mode") == env.OnlyManifestsMode {
 		logrus.Debug("Skipping ETCDTransform report, only manifests mode was set")
 		return ReportOutput{}, nil
 	}

--- a/pkg/transform/etcd_transform.go
+++ b/pkg/transform/etcd_transform.go
@@ -37,6 +37,11 @@ func (e ETCDExtraction) Transform() ([]Output, error) {
 }
 
 func (e ETCDExtraction) buildReportOutput() (Output, error) {
+	if env.Config().GetString("Mode") == env.OnlyManifestMode {
+		logrus.Debug("Skipping ETCDTransform report, only manifests mode was set")
+		return ReportOutput{}, nil
+	}
+
 	componentReport := ComponentReport{
 		Component: ETCDComponentName,
 	}

--- a/pkg/transform/image_transform.go
+++ b/pkg/transform/image_transform.go
@@ -55,6 +55,11 @@ func (e ImageExtraction) Transform() ([]Output, error) {
 }
 
 func (e ImageExtraction) buildManifestOutput() (Output, error) {
+	if env.Config().GetString("Mode") == env.OnlyReportMode {
+		logrus.Debug("Skipping ImageTransform manifests, only report mode was set")
+		return ReportOutput{}, nil
+	}
+
 	var manifests []Manifest
 
 	const (
@@ -97,6 +102,11 @@ func (e ImageExtraction) buildManifestOutput() (Output, error) {
 }
 
 func (e ImageExtraction) buildReportOutput() (Output, error) {
+	if env.Config().GetString("Mode") == env.OnlyManifestMode {
+		logrus.Debug("Skipping ImageTransform report, only manifests mode was set")
+		return ReportOutput{}, nil
+	}
+
 	componentReport := ComponentReport{
 		Component: ImageComponentName,
 	}

--- a/pkg/transform/image_transform.go
+++ b/pkg/transform/image_transform.go
@@ -102,7 +102,7 @@ func (e ImageExtraction) buildManifestOutput() (Output, error) {
 }
 
 func (e ImageExtraction) buildReportOutput() (Output, error) {
-	if env.Config().GetString("Mode") == env.OnlyManifestMode {
+	if env.Config().GetString("Mode") == env.OnlyManifestsMode {
 		logrus.Debug("Skipping ImageTransform report, only manifests mode was set")
 		return ReportOutput{}, nil
 	}

--- a/pkg/transform/oauth_transform.go
+++ b/pkg/transform/oauth_transform.go
@@ -96,7 +96,7 @@ func (e OAuthExtraction) buildManifestOutput() (Output, error) {
 }
 
 func (e OAuthExtraction) buildReportOutput() (Output, error) {
-	if env.Config().GetString("Mode") == env.OnlyManifestMode {
+	if env.Config().GetString("Mode") == env.OnlyManifestsMode {
 		logrus.Debug("Skipping OAuthTransform report, only manifests mode was set")
 		return ReportOutput{}, nil
 	}

--- a/pkg/transform/oauth_transform.go
+++ b/pkg/transform/oauth_transform.go
@@ -43,6 +43,11 @@ func (e OAuthExtraction) Transform() ([]Output, error) {
 }
 
 func (e OAuthExtraction) buildManifestOutput() (Output, error) {
+	if env.Config().GetString("Mode") == env.OnlyReportMode {
+		logrus.Debug("Skipping OAuthTransform manifests, only report mode was set")
+		return ReportOutput{}, nil
+	}
+
 	var ocp4Cluster Cluster
 
 	oauthResources, err := oauth.Translate(e.IdentityProviders, e.TokenConfig, e.Templates)
@@ -91,6 +96,11 @@ func (e OAuthExtraction) buildManifestOutput() (Output, error) {
 }
 
 func (e OAuthExtraction) buildReportOutput() (Output, error) {
+	if env.Config().GetString("Mode") == env.OnlyManifestMode {
+		logrus.Debug("Skipping OAuthTransform report, only manifests mode was set")
+		return ReportOutput{}, nil
+	}
+
 	componentReport := ComponentReport{
 		Component: OAuthComponentName,
 	}

--- a/pkg/transform/project_transform.go
+++ b/pkg/transform/project_transform.go
@@ -64,7 +64,7 @@ func (e ProjectExtraction) buildManifestOutput() (Output, error) {
 }
 
 func (e ProjectExtraction) buildReportOutput() (Output, error) {
-	if env.Config().GetString("Mode") == env.OnlyManifestMode {
+	if env.Config().GetString("Mode") == env.OnlyManifestsMode {
 		return ReportOutput{}, nil
 	}
 

--- a/pkg/transform/project_transform.go
+++ b/pkg/transform/project_transform.go
@@ -39,6 +39,10 @@ func (e ProjectExtraction) Transform() ([]Output, error) {
 }
 
 func (e ProjectExtraction) buildManifestOutput() (Output, error) {
+	if env.Config().GetString("Mode") == env.OnlyReportMode {
+		return ReportOutput{}, nil
+	}
+
 	var manifests []Manifest
 
 	projectCR, err := project.Translate(e.MasterConfig.ProjectConfig)
@@ -60,6 +64,10 @@ func (e ProjectExtraction) buildManifestOutput() (Output, error) {
 }
 
 func (e ProjectExtraction) buildReportOutput() (Output, error) {
+	if env.Config().GetString("Mode") == env.OnlyManifestMode {
+		return ReportOutput{}, nil
+	}
+
 	componentReport := ComponentReport{
 		Component: ProjectComponentName,
 	}

--- a/pkg/transform/report_output.go
+++ b/pkg/transform/report_output.go
@@ -35,7 +35,7 @@ func (r ReportOutput) Flush() error {
 
 // DumpReports creates OCDs files
 func DumpReports(r ReportOutput) {
-	if env.Config().GetString("Mode") == env.OnlyManifestMode {
+	if env.Config().GetString("Mode") == env.OnlyManifestsMode {
 		return
 	}
 

--- a/pkg/transform/report_output.go
+++ b/pkg/transform/report_output.go
@@ -3,6 +3,7 @@ package transform
 import (
 	"encoding/json"
 
+	"github.com/fusor/cpma/pkg/env"
 	"github.com/fusor/cpma/pkg/io"
 	"github.com/fusor/cpma/pkg/transform/cluster"
 	"github.com/sirupsen/logrus"
@@ -34,6 +35,10 @@ func (r ReportOutput) Flush() error {
 
 // DumpReports creates OCDs files
 func DumpReports(r ReportOutput) {
+	if env.Config().GetString("Mode") == env.OnlyManifestMode {
+		return
+	}
+
 	var existingReports ReportOutput
 
 	jsonFile := "report.json"

--- a/pkg/transform/scheduler_transform.go
+++ b/pkg/transform/scheduler_transform.go
@@ -37,6 +37,10 @@ func (e SchedulerExtraction) Transform() ([]Output, error) {
 }
 
 func (e SchedulerExtraction) buildManifestOutput() (Output, error) {
+	if env.Config().GetString("Mode") == env.OnlyReportMode {
+		return ReportOutput{}, nil
+	}
+
 	var manifests []Manifest
 
 	schedulerCR, err := scheduler.Translate(e.MasterConfig)
@@ -58,6 +62,11 @@ func (e SchedulerExtraction) buildManifestOutput() (Output, error) {
 }
 
 func (e SchedulerExtraction) buildReportOutput() (Output, error) {
+	if env.Config().GetString("Mode") == env.OnlyManifestMode {
+		logrus.Debug("Skipping SchedulerTransform report, only manifests mode was set")
+		return ReportOutput{}, nil
+	}
+
 	componentReport := ComponentReport{
 		Component: SchedulerComponentName,
 	}

--- a/pkg/transform/scheduler_transform.go
+++ b/pkg/transform/scheduler_transform.go
@@ -62,7 +62,7 @@ func (e SchedulerExtraction) buildManifestOutput() (Output, error) {
 }
 
 func (e SchedulerExtraction) buildReportOutput() (Output, error) {
-	if env.Config().GetString("Mode") == env.OnlyManifestMode {
+	if env.Config().GetString("Mode") == env.OnlyManifestsMode {
 		logrus.Debug("Skipping SchedulerTransform report, only manifests mode was set")
 		return ReportOutput{}, nil
 	}

--- a/pkg/transform/sdn_transform.go
+++ b/pkg/transform/sdn_transform.go
@@ -68,7 +68,7 @@ func (e SDNExtraction) buildManifestOutput() (Output, error) {
 }
 
 func (e SDNExtraction) buildReportOutput() (Output, error) {
-	if env.Config().GetString("Mode") == env.OnlyManifestMode {
+	if env.Config().GetString("Mode") == env.OnlyManifestsMode {
 		logrus.Debug("Skipping SDNTransform report, only manifests mode was set")
 		return ReportOutput{}, nil
 	}

--- a/pkg/transform/sdn_transform.go
+++ b/pkg/transform/sdn_transform.go
@@ -42,6 +42,11 @@ func (e SDNExtraction) Transform() ([]Output, error) {
 }
 
 func (e SDNExtraction) buildManifestOutput() (Output, error) {
+	if env.Config().GetString("Mode") == env.OnlyReportMode {
+		logrus.Debug("Skipping SDNTransform manifests, only report mode was set")
+		return ReportOutput{}, nil
+	}
+
 	var manifests []Manifest
 
 	networkCR, err := sdn.Translate(e.MasterConfig)
@@ -63,6 +68,11 @@ func (e SDNExtraction) buildManifestOutput() (Output, error) {
 }
 
 func (e SDNExtraction) buildReportOutput() (Output, error) {
+	if env.Config().GetString("Mode") == env.OnlyManifestMode {
+		logrus.Debug("Skipping SDNTransform report, only manifests mode was set")
+		return ReportOutput{}, nil
+	}
+
 	componentReport := ComponentReport{
 		Component: SDNComponentName,
 	}

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -1,6 +1,7 @@
 package transform
 
 import (
+	"github.com/fusor/cpma/pkg/env"
 	"github.com/fusor/cpma/pkg/io"
 	"github.com/fusor/cpma/pkg/transform/configmaps"
 	"github.com/fusor/cpma/pkg/transform/secrets"
@@ -151,6 +152,10 @@ func GenYAML(CR interface{}) ([]byte, error) {
 }
 
 func openReports() {
+	if env.Config().GetString("Mode") == env.OnlyManifestMode {
+		return
+	}
+
 	jsonfile := "report.json"
 	emptyReport := []byte("{}")
 

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -152,7 +152,7 @@ func GenYAML(CR interface{}) ([]byte, error) {
 }
 
 func openReports() {
-	if env.Config().GetString("Mode") == env.OnlyManifestMode {
+	if env.Config().GetString("Mode") == env.OnlyManifestsMode {
 		return
 	}
 


### PR DESCRIPTION
Add ability to generate either report or CR. I know this is not the best solution, but it is tested in e2e tests. We can rethink the approach after feature freeze.


Closes https://github.com/fusor/cpma/issues/310