### PR TITLE
Support for multiple output formats

### DIFF
--- a/pkg/transform/api_transform.go
+++ b/pkg/transform/api_transform.go
@@ -8,6 +8,7 @@ import (
 	"github.com/fusor/cpma/pkg/decode"
 	"github.com/fusor/cpma/pkg/env"
 	"github.com/fusor/cpma/pkg/io"
+	"github.com/fusor/cpma/pkg/transform/reportoutput"
 	"github.com/sirupsen/logrus"
 )
 
@@ -33,17 +34,13 @@ func (e APIExtraction) Transform() ([]Output, error) {
 	outputs := []Output{}
 	if env.Config().GetBool("Reporting") {
 		logrus.Info("APITransform::Transform:Reports")
-		reports, err := e.buildReportOutput()
-		if err != nil {
-			return nil, err
-		}
-		outputs = append(outputs, reports)
+		e.buildReportOutput()
 	}
 	return outputs, nil
 }
 
-func (e APIExtraction) buildReportOutput() (Output, error) {
-	componentReport := ComponentReport{
+func (e APIExtraction) buildReportOutput() {
+	componentReport := reportoutput.ComponentReport{
 		Component: APIComponentName,
 	}
 
@@ -56,7 +53,7 @@ func (e APIExtraction) buildReportOutput() (Output, error) {
 	}
 
 	componentReport.Reports = append(componentReport.Reports,
-		Report{
+		reportoutput.Report{
 			Name:       "API",
 			Kind:       "Port",
 			Supported:  false,
@@ -64,11 +61,7 @@ func (e APIExtraction) buildReportOutput() (Output, error) {
 			Comment:    fmt.Sprintf("The API Port for Openshift 4 is 6443 and is non-configurable. Your OCP 3 cluster is currently configured to use port %v", port),
 		})
 
-	reportOutput := ReportOutput{
-		ComponentReports: []ComponentReport{componentReport},
-	}
-
-	return reportOutput, nil
+	finalReportOutput.report.ComponentReports = append(finalReportOutput.report.ComponentReports, componentReport)
 }
 
 // Extract collects API configuration from an OCP3 cluster

--- a/pkg/transform/api_transform.go
+++ b/pkg/transform/api_transform.go
@@ -31,12 +31,11 @@ type APITransform struct {
 
 // Transform converts data collected from an OCP3 into a useful output
 func (e APIExtraction) Transform() ([]Output, error) {
-	outputs := []Output{}
 	if env.Config().GetBool("Reporting") {
 		logrus.Info("APITransform::Transform:Reports")
 		e.buildReportOutput()
 	}
-	return outputs, nil
+	return nil, nil
 }
 
 func (e APIExtraction) buildReportOutput() {
@@ -61,7 +60,7 @@ func (e APIExtraction) buildReportOutput() {
 			Comment:    fmt.Sprintf("The API Port for Openshift 4 is 6443 and is non-configurable. Your OCP 3 cluster is currently configured to use port %v", port),
 		})
 
-	finalReportOutput.report.ComponentReports = append(finalReportOutput.report.ComponentReports, componentReport)
+	FinalReportOutput.Report.ComponentReports = append(FinalReportOutput.Report.ComponentReports, componentReport)
 }
 
 // Extract collects API configuration from an OCP3 cluster

--- a/pkg/transform/cluster_transform.go
+++ b/pkg/transform/cluster_transform.go
@@ -48,7 +48,7 @@ func (e ClusterExtraction) Transform() ([]Output, error) {
 			StorageClassList:     e.StorageClassList,
 		})
 
-		finalReportOutput.report.ClusterReport = clusterReport
+		FinalReportOutput.Report.ClusterReport = clusterReport
 	}
 
 	return outputs, nil

--- a/pkg/transform/cluster_transform.go
+++ b/pkg/transform/cluster_transform.go
@@ -48,11 +48,7 @@ func (e ClusterExtraction) Transform() ([]Output, error) {
 			StorageClassList:     e.StorageClassList,
 		})
 
-		output := ReportOutput{
-			ClusterReport: clusterReport,
-		}
-
-		outputs = append(outputs, output)
+		finalReportOutput.report.ClusterReport = clusterReport
 	}
 
 	return outputs, nil

--- a/pkg/transform/cluster_transform_test.go
+++ b/pkg/transform/cluster_transform_test.go
@@ -6,8 +6,10 @@ import (
 	"testing"
 
 	"github.com/fusor/cpma/pkg/api"
+	"github.com/fusor/cpma/pkg/env"
 	"github.com/fusor/cpma/pkg/transform"
 	cpmatest "github.com/fusor/cpma/pkg/transform/internal/test"
+	"github.com/fusor/cpma/pkg/transform/reportoutput"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -28,6 +30,11 @@ func TestClusterExtractionTransform(t *testing.T) {
 		},
 	}
 	clusterExtraction := transform.ClusterExtraction{apiResources}
+
+	transform.FinalReportOutput = transform.Report{}
+	env.Config().Set("Reporting", true)
+	env.Config().Set("Manifests", true)
+
 	actualClusterOutput, err := clusterExtraction.Transform()
 	require.NoError(t, err)
 
@@ -41,8 +48,8 @@ func TestClusterExtractionTransform(t *testing.T) {
 	assert.Equal(t, "100_CPMA-namespacetest1-resource-quota-resourcequota1.yaml", manifests[1].Name)
 	assert.Equal(t, expectedResourceQuotaCRD, manifests[1].CRD)
 
-	report := transform.ReportOutput{
-		ClusterReport: actualClusterOutput[1].(transform.ReportOutput).ClusterReport,
+	report := reportoutput.ReportOutput{
+		ClusterReport: transform.FinalReportOutput.Report.ClusterReport,
 	}
 	actualClusterReportJSON, err := json.MarshalIndent(report, "", " ")
 	require.NoError(t, err)

--- a/pkg/transform/crio_transform.go
+++ b/pkg/transform/crio_transform.go
@@ -4,6 +4,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/fusor/cpma/pkg/env"
 	"github.com/fusor/cpma/pkg/io"
+	"github.com/fusor/cpma/pkg/transform/reportoutput"
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -80,11 +81,7 @@ func (e CrioExtraction) Transform() ([]Output, error) {
 
 	if env.Config().GetBool("Reporting") {
 		logrus.Info("CrioTransform::Transform:Reports")
-		reports, err := e.buildReportOutput()
-		if err != nil {
-			return nil, err
-		}
-		outputs = append(outputs, reports)
+		e.buildReportOutput()
 	}
 
 	return outputs, nil
@@ -124,8 +121,8 @@ func (e CrioExtraction) buildManifestOutput() (Output, error) {
 	}, nil
 }
 
-func (e CrioExtraction) buildReportOutput() (Output, error) {
-	componentReport := ComponentReport{
+func (e CrioExtraction) buildReportOutput() {
+	componentReport := reportoutput.ComponentReport{
 		Component: CrioComponentName,
 	}
 
@@ -134,7 +131,7 @@ func (e CrioExtraction) buildReportOutput() (Output, error) {
 
 	if e.Crio.PidsLimit != 0 {
 		componentReport.Reports = append(componentReport.Reports,
-			Report{
+			reportoutput.Report{
 				Name:       "pidsLimit",
 				Kind:       "Configuration",
 				Supported:  supported,
@@ -143,7 +140,7 @@ func (e CrioExtraction) buildReportOutput() (Output, error) {
 	}
 	if e.Crio.LogLevel != "" {
 		componentReport.Reports = append(componentReport.Reports,
-			Report{
+			reportoutput.Report{
 				Name:       "logLevel",
 				Kind:       "Configuration",
 				Supported:  supported,
@@ -152,7 +149,7 @@ func (e CrioExtraction) buildReportOutput() (Output, error) {
 	}
 	if e.Crio.LogSizeMax != 0 {
 		componentReport.Reports = append(componentReport.Reports,
-			Report{
+			reportoutput.Report{
 				Name:       "logSizeMax",
 				Kind:       "Configuration",
 				Supported:  supported,
@@ -161,7 +158,7 @@ func (e CrioExtraction) buildReportOutput() (Output, error) {
 	}
 	if e.Crio.InfraImage != "" {
 		componentReport.Reports = append(componentReport.Reports,
-			Report{
+			reportoutput.Report{
 				Name:       "infrImage",
 				Kind:       "Configuration",
 				Supported:  supported,
@@ -169,11 +166,7 @@ func (e CrioExtraction) buildReportOutput() (Output, error) {
 			})
 	}
 
-	reportOutput := ReportOutput{
-		ComponentReports: []ComponentReport{componentReport},
-	}
-
-	return reportOutput, nil
+	finalReportOutput.report.ComponentReports = append(finalReportOutput.report.ComponentReports, componentReport)
 }
 
 // Extract collects Crio configuration from an OCP3 cluster

--- a/pkg/transform/crio_transform.go
+++ b/pkg/transform/crio_transform.go
@@ -166,7 +166,7 @@ func (e CrioExtraction) buildReportOutput() {
 			})
 	}
 
-	finalReportOutput.report.ComponentReports = append(finalReportOutput.report.ComponentReports, componentReport)
+	FinalReportOutput.Report.ComponentReports = append(FinalReportOutput.Report.ComponentReports, componentReport)
 }
 
 // Extract collects Crio configuration from an OCP3 cluster

--- a/pkg/transform/docker_transform.go
+++ b/pkg/transform/docker_transform.go
@@ -41,7 +41,7 @@ func (e DockerExtraction) buildReportOutput() {
 			Comment:    "The Docker runtime has been replaced with CRI-O",
 		})
 
-	finalReportOutput.report.ComponentReports = append(finalReportOutput.report.ComponentReports, componentReport)
+	FinalReportOutput.Report.ComponentReports = append(FinalReportOutput.Report.ComponentReports, componentReport)
 }
 
 // Extract collects Docker configuration from an OCP3 cluster

--- a/pkg/transform/docker_transform.go
+++ b/pkg/transform/docker_transform.go
@@ -3,6 +3,7 @@ package transform
 import (
 	"github.com/fusor/cpma/pkg/env"
 	"github.com/fusor/cpma/pkg/io/remotehost"
+	"github.com/fusor/cpma/pkg/transform/reportoutput"
 	"github.com/sirupsen/logrus"
 )
 
@@ -21,22 +22,18 @@ type DockerTransform struct {
 func (e DockerExtraction) Transform() ([]Output, error) {
 	if env.Config().GetBool("Reporting") {
 		logrus.Info("DockerTransform::Transform:Reports")
-		reports, err := e.buildReportOutput()
-		if err != nil {
-			return nil, err
-		}
-		return []Output{reports}, nil
+		e.buildReportOutput()
 	}
 	return nil, nil
 }
 
-func (e DockerExtraction) buildReportOutput() (Output, error) {
-	componentReport := ComponentReport{
+func (e DockerExtraction) buildReportOutput() {
+	componentReport := reportoutput.ComponentReport{
 		Component: DockerComponentName,
 	}
 
 	componentReport.Reports = append(componentReport.Reports,
-		Report{
+		reportoutput.Report{
 			Name:       "Docker",
 			Kind:       "Container Runtime",
 			Supported:  false,
@@ -44,11 +41,7 @@ func (e DockerExtraction) buildReportOutput() (Output, error) {
 			Comment:    "The Docker runtime has been replaced with CRI-O",
 		})
 
-	reportOutput := ReportOutput{
-		ComponentReports: []ComponentReport{componentReport},
-	}
-
-	return reportOutput, nil
+	finalReportOutput.report.ComponentReports = append(finalReportOutput.report.ComponentReports, componentReport)
 }
 
 // Extract collects Docker configuration from an OCP3 cluster

--- a/pkg/transform/docker_transform_test.go
+++ b/pkg/transform/docker_transform_test.go
@@ -3,7 +3,9 @@ package transform_test
 import (
 	"testing"
 
+	"github.com/fusor/cpma/pkg/env"
 	"github.com/fusor/cpma/pkg/transform"
+	"github.com/fusor/cpma/pkg/transform/reportoutput"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -14,12 +16,12 @@ func loadDockerExtraction() (transform.DockerExtraction, error) {
 }
 
 func TestDockerExtractionTransform(t *testing.T) {
-	expectedReport := transform.ComponentReport{
+	expectedReport := reportoutput.ComponentReport{
 		Component: "Docker",
 	}
 
 	expectedReport.Reports = append(expectedReport.Reports,
-		transform.Report{
+		reportoutput.Report{
 			Name:       "Docker",
 			Kind:       "Container Runtime",
 			Supported:  false,
@@ -27,13 +29,13 @@ func TestDockerExtractionTransform(t *testing.T) {
 			Comment:    "The Docker runtime has been replaced with CRI-O",
 		})
 
-	expectedReportOutput := transform.ReportOutput{
-		ComponentReports: []transform.ComponentReport{expectedReport},
+	expectedReportOutput := reportoutput.ReportOutput{
+		ComponentReports: []reportoutput.ComponentReport{expectedReport},
 	}
 
 	testCases := []struct {
 		name            string
-		expectedReports transform.ReportOutput
+		expectedReports reportoutput.ReportOutput
 	}{
 		{
 			name:            "transform crio extraction",
@@ -43,11 +45,12 @@ func TestDockerExtractionTransform(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualReportsChan := make(chan transform.ReportOutput)
+			actualReportsChan := make(chan reportoutput.ReportOutput)
+			transform.FinalReportOutput = transform.Report{}
 
 			// Override flush method
-			transform.ReportOutputFlush = func(reports transform.ReportOutput) error {
-				actualReportsChan <- reports
+			transform.ReportOutputFlush = func(reports transform.Report) error {
+				actualReportsChan <- reports.Report
 				return nil
 			}
 
@@ -55,17 +58,17 @@ func TestDockerExtractionTransform(t *testing.T) {
 			require.NoError(t, err)
 
 			go func() {
-				transformOutput, err := testExtraction.Transform()
+				env.Config().Set("Reporting", true)
+				env.Config().Set("Manifests", true)
+				_, err := testExtraction.Transform()
 				if err != nil {
 					t.Error(err)
 				}
-				for _, output := range transformOutput {
-					output.Flush()
-				}
+				transform.FinalReportOutput.Flush()
 			}()
 
 			actualReports := <-actualReportsChan
-			assert.Equal(t, actualReports, tc.expectedReports)
+			assert.Equal(t, actualReports.ComponentReports, tc.expectedReports.ComponentReports)
 		})
 
 	}

--- a/pkg/transform/etcd_transform.go
+++ b/pkg/transform/etcd_transform.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/fusor/cpma/pkg/env"
 	"github.com/fusor/cpma/pkg/io"
+	"github.com/fusor/cpma/pkg/transform/reportoutput"
 	"github.com/sirupsen/logrus"
 )
 
@@ -29,17 +30,13 @@ type ETCDTransform struct {
 func (e ETCDExtraction) Transform() ([]Output, error) {
 	if env.Config().GetBool("Reporting") {
 		logrus.Info("ETCDTransform::Transform:Reports")
-		reports, err := e.buildReportOutput()
-		if err != nil {
-			return nil, err
-		}
-		return []Output{reports}, nil
+		e.buildReportOutput()
 	}
 	return nil, nil
 }
 
-func (e ETCDExtraction) buildReportOutput() (Output, error) {
-	componentReport := ComponentReport{
+func (e ETCDExtraction) buildReportOutput() {
+	componentReport := reportoutput.ComponentReport{
 		Component: ETCDComponentName,
 	}
 
@@ -57,7 +54,7 @@ func (e ETCDExtraction) buildReportOutput() (Output, error) {
 	}
 
 	componentReport.Reports = append(componentReport.Reports,
-		Report{
+		reportoutput.Report{
 			Name:       "ETCD Client Port",
 			Kind:       "Configuration",
 			Supported:  false,
@@ -66,7 +63,7 @@ func (e ETCDExtraction) buildReportOutput() (Output, error) {
 		})
 
 	componentReport.Reports = append(componentReport.Reports,
-		Report{
+		reportoutput.Report{
 			Name:       "ETCD TLS Cipher Suites",
 			Kind:       "Configuration",
 			Supported:  false,
@@ -74,11 +71,7 @@ func (e ETCDExtraction) buildReportOutput() (Output, error) {
 			Comment:    TLSMessage,
 		})
 
-	reportOutput := ReportOutput{
-		ComponentReports: []ComponentReport{componentReport},
-	}
-
-	return reportOutput, nil
+	finalReportOutput.report.ComponentReports = append(finalReportOutput.report.ComponentReports, componentReport)
 }
 
 // Extract collects ETCD configuration from an OCP3 cluster

--- a/pkg/transform/etcd_transform.go
+++ b/pkg/transform/etcd_transform.go
@@ -71,7 +71,7 @@ func (e ETCDExtraction) buildReportOutput() {
 			Comment:    TLSMessage,
 		})
 
-	finalReportOutput.report.ComponentReports = append(finalReportOutput.report.ComponentReports, componentReport)
+	FinalReportOutput.Report.ComponentReports = append(FinalReportOutput.Report.ComponentReports, componentReport)
 }
 
 // Extract collects ETCD configuration from an OCP3 cluster

--- a/pkg/transform/image_transform.go
+++ b/pkg/transform/image_transform.go
@@ -8,8 +8,8 @@ import (
 	"github.com/fusor/cpma/pkg/env"
 	"github.com/fusor/cpma/pkg/io"
 	"github.com/fusor/cpma/pkg/transform/image"
-	"github.com/fusor/cpma/pkg/transform/reportoutput"
 	"github.com/fusor/cpma/pkg/transform/registries"
+	"github.com/fusor/cpma/pkg/transform/reportoutput"
 	configv1 "github.com/openshift/api/config/v1"
 	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	"github.com/sirupsen/logrus"
@@ -209,7 +209,7 @@ func (e ImageExtraction) buildReportOutput() {
 			Comment:    "Not supported by OCP4",
 		})
 
-	finalReportOutput.report.ComponentReports = append(finalReportOutput.report.ComponentReports, componentReport)
+	FinalReportOutput.Report.ComponentReports = append(FinalReportOutput.Report.ComponentReports, componentReport)
 }
 
 // Extract collects image configuration information from an OCP3 cluster

--- a/pkg/transform/image_transform_test.go
+++ b/pkg/transform/image_transform_test.go
@@ -7,8 +7,10 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/fusor/cpma/pkg/decode"
+	"github.com/fusor/cpma/pkg/env"
 	"github.com/fusor/cpma/pkg/io"
 	"github.com/fusor/cpma/pkg/transform"
+	"github.com/fusor/cpma/pkg/transform/reportoutput"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -35,7 +37,7 @@ func TestImageExtractionTransform(t *testing.T) {
 	expectedManifests = append(expectedManifests,
 		transform.Manifest{Name: "100_CPMA-cluster-config-image.yaml", CRD: expectedImageCRYAML})
 
-	expectedReport := transform.ReportOutput{}
+	expectedReport := reportoutput.ReportOutput{}
 	jsonData, err := io.ReadFile("testdata/expected-report-image.json")
 	require.NoError(t, err)
 
@@ -45,7 +47,7 @@ func TestImageExtractionTransform(t *testing.T) {
 	testCases := []struct {
 		name              string
 		expectedManifests []transform.Manifest
-		expectedReports   transform.ReportOutput
+		expectedReports   reportoutput.ReportOutput
 	}{
 		{
 			name:              "transform image extraction",
@@ -57,15 +59,16 @@ func TestImageExtractionTransform(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			actualManifestsChan := make(chan []transform.Manifest)
-			actualReportsChan := make(chan transform.ReportOutput)
+			actualReportsChan := make(chan reportoutput.ReportOutput)
+			transform.FinalReportOutput = transform.Report{}
 
 			// Override flush methods
 			transform.ManifestOutputFlush = func(manifests []transform.Manifest) error {
 				actualManifestsChan <- manifests
 				return nil
 			}
-			transform.ReportOutputFlush = func(reports transform.ReportOutput) error {
-				actualReportsChan <- reports
+			transform.ReportOutputFlush = func(reports transform.Report) error {
+				actualReportsChan <- reports.Report
 				return nil
 			}
 
@@ -73,6 +76,9 @@ func TestImageExtractionTransform(t *testing.T) {
 			require.NoError(t, err)
 
 			go func() {
+				env.Config().Set("Reporting", true)
+				env.Config().Set("Manifests", true)
+
 				transformOutput, err := testExtraction.Transform()
 				if err != nil {
 					t.Error(err)
@@ -80,12 +86,13 @@ func TestImageExtractionTransform(t *testing.T) {
 				for _, output := range transformOutput {
 					output.Flush()
 				}
+				transform.FinalReportOutput.Flush()
 			}()
 
 			actualManifests := <-actualManifestsChan
 			assert.Equal(t, actualManifests, tc.expectedManifests)
 			actualReports := <-actualReportsChan
-			assert.Equal(t, actualReports, tc.expectedReports)
+			assert.Equal(t, actualReports.ComponentReports, tc.expectedReports.ComponentReports)
 		})
 	}
 }

--- a/pkg/transform/oauth_transform.go
+++ b/pkg/transform/oauth_transform.go
@@ -204,7 +204,7 @@ func (e OAuthExtraction) buildReportOutput() {
 			Comment:    "Translation of SessionConfig is not supported",
 		})
 
-	finalReportOutput.report.ComponentReports = append(finalReportOutput.report.ComponentReports, componentReport)
+	FinalReportOutput.Report.ComponentReports = append(FinalReportOutput.Report.ComponentReports, componentReport)
 }
 
 // Extract collects OAuth configuration from an OCP3 cluster

--- a/pkg/transform/oauth_transform.go
+++ b/pkg/transform/oauth_transform.go
@@ -8,6 +8,7 @@ import (
 	"github.com/fusor/cpma/pkg/env"
 	"github.com/fusor/cpma/pkg/io"
 	"github.com/fusor/cpma/pkg/transform/oauth"
+	"github.com/fusor/cpma/pkg/transform/reportoutput"
 	configv1 "github.com/openshift/api/legacyconfig/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -42,11 +43,7 @@ func (e OAuthExtraction) Transform() ([]Output, error) {
 
 	if env.Config().GetBool("Reporting") {
 		logrus.Info("OAuthTransform::Transform:Reports")
-		reports, err := e.buildReportOutput()
-		if err != nil {
-			return nil, err
-		}
-		outputs = append(outputs, reports)
+		e.buildReportOutput()
 	}
 
 	return outputs, nil
@@ -100,8 +97,8 @@ func (e OAuthExtraction) buildManifestOutput() (Output, error) {
 	return ManifestOutput{Manifests: manifests}, nil
 }
 
-func (e OAuthExtraction) buildReportOutput() (Output, error) {
-	componentReport := ComponentReport{
+func (e OAuthExtraction) buildReportOutput() {
+	componentReport := reportoutput.ComponentReport{
 		Component: OAuthComponentName,
 	}
 
@@ -117,7 +114,7 @@ func (e OAuthExtraction) buildReportOutput() (Output, error) {
 			"KeystonePasswordIdentityProvider",
 			"BasicAuthPasswordIdentityProvider":
 			componentReport.Reports = append(componentReport.Reports,
-				Report{
+				reportoutput.Report{
 					Name:       p.Kind,
 					Kind:       "IdentityProviders",
 					Supported:  true,
@@ -126,7 +123,7 @@ func (e OAuthExtraction) buildReportOutput() (Output, error) {
 				})
 		default:
 			componentReport.Reports = append(componentReport.Reports,
-				Report{
+				reportoutput.Report{
 					Name:       p.Kind,
 					Kind:       "IdentityProviders",
 					Supported:  false,
@@ -137,7 +134,7 @@ func (e OAuthExtraction) buildReportOutput() (Output, error) {
 	}
 
 	componentReport.Reports = append(componentReport.Reports,
-		Report{
+		reportoutput.Report{
 			Name:       "AccessTokenMaxAgeSeconds",
 			Kind:       "TokenConfig",
 			Supported:  true,
@@ -145,7 +142,7 @@ func (e OAuthExtraction) buildReportOutput() (Output, error) {
 		})
 
 	componentReport.Reports = append(componentReport.Reports,
-		Report{
+		reportoutput.Report{
 			Name:       "AuthorizeTokenMaxAgeSeconds",
 			Kind:       "TokenConfig",
 			Supported:  false,
@@ -154,7 +151,7 @@ func (e OAuthExtraction) buildReportOutput() (Output, error) {
 		})
 
 	componentReport.Reports = append(componentReport.Reports,
-		Report{
+		reportoutput.Report{
 			Name:       "",
 			Kind:       "AssetPublicURL",
 			Supported:  false,
@@ -163,7 +160,7 @@ func (e OAuthExtraction) buildReportOutput() (Output, error) {
 		})
 
 	componentReport.Reports = append(componentReport.Reports,
-		Report{
+		reportoutput.Report{
 			Name:       "",
 			Kind:       "MasterPublicURL",
 			Supported:  false,
@@ -172,7 +169,7 @@ func (e OAuthExtraction) buildReportOutput() (Output, error) {
 		})
 
 	componentReport.Reports = append(componentReport.Reports,
-		Report{
+		reportoutput.Report{
 			Name:       "",
 			Kind:       "MasterCA",
 			Supported:  false,
@@ -181,7 +178,7 @@ func (e OAuthExtraction) buildReportOutput() (Output, error) {
 		})
 
 	componentReport.Reports = append(componentReport.Reports,
-		Report{
+		reportoutput.Report{
 			Name:       "",
 			Kind:       "MasterURL",
 			Supported:  false,
@@ -190,7 +187,7 @@ func (e OAuthExtraction) buildReportOutput() (Output, error) {
 		})
 
 	componentReport.Reports = append(componentReport.Reports,
-		Report{
+		reportoutput.Report{
 			Name:       "",
 			Kind:       "GrantConfig",
 			Supported:  false,
@@ -199,7 +196,7 @@ func (e OAuthExtraction) buildReportOutput() (Output, error) {
 		})
 
 	componentReport.Reports = append(componentReport.Reports,
-		Report{
+		reportoutput.Report{
 			Name:       "",
 			Kind:       "SessionConfig",
 			Supported:  false,
@@ -207,11 +204,7 @@ func (e OAuthExtraction) buildReportOutput() (Output, error) {
 			Comment:    "Translation of SessionConfig is not supported",
 		})
 
-	reportOutput := ReportOutput{
-		ComponentReports: []ComponentReport{componentReport},
-	}
-
-	return reportOutput, nil
+	finalReportOutput.report.ComponentReports = append(finalReportOutput.report.ComponentReports, componentReport)
 }
 
 // Extract collects OAuth configuration from an OCP3 cluster

--- a/pkg/transform/oauth_transform_test.go
+++ b/pkg/transform/oauth_transform_test.go
@@ -5,10 +5,12 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/fusor/cpma/pkg/env"
 	"github.com/fusor/cpma/pkg/io"
 	"github.com/fusor/cpma/pkg/transform"
 	cpmatest "github.com/fusor/cpma/pkg/transform/internal/test"
 	"github.com/fusor/cpma/pkg/transform/oauth"
+	"github.com/fusor/cpma/pkg/transform/reportoutput"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -111,7 +113,7 @@ func TestOAuthExtractionTransform(t *testing.T) {
 	expectedManifests = append(expectedManifests,
 		transform.Manifest{Name: "100_CPMA-cluster-config-configmap-requestheader-configmap.yaml", CRD: expectedConfigmapRequestheader})
 
-	expectedReport := transform.ReportOutput{}
+	expectedReport := reportoutput.ReportOutput{}
 	jsonData, err := io.ReadFile("testdata/expected-report-oauth.json")
 	require.NoError(t, err)
 
@@ -121,7 +123,7 @@ func TestOAuthExtractionTransform(t *testing.T) {
 	testCases := []struct {
 		name              string
 		expectedManifests []transform.Manifest
-		expectedReports   transform.ReportOutput
+		expectedReports   reportoutput.ReportOutput
 	}{
 		{
 			name:              "transform registries extraction",
@@ -133,15 +135,16 @@ func TestOAuthExtractionTransform(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			actualManifestsChan := make(chan []transform.Manifest)
-			actualReportsChan := make(chan transform.ReportOutput)
+			actualReportsChan := make(chan reportoutput.ReportOutput)
+			transform.FinalReportOutput = transform.Report{}
 
 			// Override flush method
 			transform.ManifestOutputFlush = func(manifests []transform.Manifest) error {
 				actualManifestsChan <- manifests
 				return nil
 			}
-			transform.ReportOutputFlush = func(reports transform.ReportOutput) error {
-				actualReportsChan <- reports
+			transform.ReportOutputFlush = func(reports transform.Report) error {
+				actualReportsChan <- reports.Report
 				return nil
 			}
 
@@ -158,6 +161,9 @@ func TestOAuthExtractionTransform(t *testing.T) {
 			}
 
 			go func() {
+				env.Config().Set("Reporting", true)
+				env.Config().Set("Manifests", true)
+
 				transformOutput, err := testExtraction.Transform()
 				if err != nil {
 					t.Error(err)
@@ -165,12 +171,13 @@ func TestOAuthExtractionTransform(t *testing.T) {
 				for _, output := range transformOutput {
 					output.Flush()
 				}
+				transform.FinalReportOutput.Flush()
 			}()
 
 			actualManifests := <-actualManifestsChan
 			assert.Equal(t, tc.expectedManifests, actualManifests)
 			actualReports := <-actualReportsChan
-			assert.Equal(t, tc.expectedReports, actualReports)
+			assert.Equal(t, actualReports.ComponentReports, tc.expectedReports.ComponentReports)
 		})
 	}
 }

--- a/pkg/transform/project_transform.go
+++ b/pkg/transform/project_transform.go
@@ -7,6 +7,7 @@ import (
 	"github.com/fusor/cpma/pkg/env"
 	"github.com/fusor/cpma/pkg/io"
 	"github.com/fusor/cpma/pkg/transform/project"
+	"github.com/fusor/cpma/pkg/transform/reportoutput"
 	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	"github.com/sirupsen/logrus"
 )
@@ -38,11 +39,7 @@ func (e ProjectExtraction) Transform() ([]Output, error) {
 
 	if env.Config().GetBool("Reporting") {
 		logrus.Info("ProjectTransform::Transform:Reports")
-		reports, err := e.buildReportOutput()
-		if err != nil {
-			return nil, err
-		}
-		outputs = append(outputs, reports)
+		e.buildReportOutput()
 	}
 
 	return outputs, nil
@@ -69,13 +66,13 @@ func (e ProjectExtraction) buildManifestOutput() (Output, error) {
 	}, nil
 }
 
-func (e ProjectExtraction) buildReportOutput() (Output, error) {
-	componentReport := ComponentReport{
+func (e ProjectExtraction) buildReportOutput() {
+	componentReport := reportoutput.ComponentReport{
 		Component: ProjectComponentName,
 	}
 
 	componentReport.Reports = append(componentReport.Reports,
-		Report{
+		reportoutput.Report{
 			Name:       "ProjectRequestMessage",
 			Kind:       "ProjectConfig",
 			Supported:  true,
@@ -84,7 +81,7 @@ func (e ProjectExtraction) buildReportOutput() (Output, error) {
 		})
 
 	componentReport.Reports = append(componentReport.Reports,
-		Report{
+		reportoutput.Report{
 			Name:       "ProjectRequestTemplate",
 			Kind:       "ProjectConfig",
 			Supported:  true,
@@ -93,7 +90,7 @@ func (e ProjectExtraction) buildReportOutput() (Output, error) {
 		})
 
 	componentReport.Reports = append(componentReport.Reports,
-		Report{
+		reportoutput.Report{
 			Name:       "DefaultNodeSelector",
 			Kind:       "ProjectConfig",
 			Supported:  false,
@@ -102,7 +99,7 @@ func (e ProjectExtraction) buildReportOutput() (Output, error) {
 		})
 
 	componentReport.Reports = append(componentReport.Reports,
-		Report{
+		reportoutput.Report{
 			Name:       "SecurityAllocator.mcsAllocatorRange",
 			Kind:       "ProjectConfig",
 			Supported:  false,
@@ -111,7 +108,7 @@ func (e ProjectExtraction) buildReportOutput() (Output, error) {
 		})
 
 	componentReport.Reports = append(componentReport.Reports,
-		Report{
+		reportoutput.Report{
 			Name:       "SecurityAllocator.mcsLabelsPerProject",
 			Kind:       "ProjectConfig",
 			Supported:  false,
@@ -120,7 +117,7 @@ func (e ProjectExtraction) buildReportOutput() (Output, error) {
 		})
 
 	componentReport.Reports = append(componentReport.Reports,
-		Report{
+		reportoutput.Report{
 			Name:       "SecurityAllocator.uidAllocatorRange",
 			Kind:       "ProjectConfig",
 			Supported:  false,
@@ -128,11 +125,7 @@ func (e ProjectExtraction) buildReportOutput() (Output, error) {
 			Comment:    fmt.Sprintf("Not supported in OCP4: %s", e.ProjectConfig.SecurityAllocator.UIDAllocatorRange),
 		})
 
-	reportOutput := ReportOutput{
-		ComponentReports: []ComponentReport{componentReport},
-	}
-
-	return reportOutput, nil
+	finalReportOutput.report.ComponentReports = append(finalReportOutput.report.ComponentReports, componentReport)
 }
 
 // Extract collects Project configuration information from an OCP3 cluster

--- a/pkg/transform/project_transform.go
+++ b/pkg/transform/project_transform.go
@@ -125,7 +125,7 @@ func (e ProjectExtraction) buildReportOutput() {
 			Comment:    fmt.Sprintf("Not supported in OCP4: %s", e.ProjectConfig.SecurityAllocator.UIDAllocatorRange),
 		})
 
-	finalReportOutput.report.ComponentReports = append(finalReportOutput.report.ComponentReports, componentReport)
+	FinalReportOutput.Report.ComponentReports = append(FinalReportOutput.Report.ComponentReports, componentReport)
 }
 
 // Extract collects Project configuration information from an OCP3 cluster

--- a/pkg/transform/report_output.go
+++ b/pkg/transform/report_output.go
@@ -7,7 +7,7 @@ import (
 
 // Report represents structure for final output
 type Report struct {
-	report reportoutput.ReportOutput
+	Report reportoutput.ReportOutput
 }
 
 // Flush reports to files
@@ -18,6 +18,6 @@ func (r Report) Flush() error {
 // ReportOutputFlush flush reports to disk
 var ReportOutputFlush = func(r Report) error {
 	logrus.Info("Flushing reports to disk")
-	reportoutput.DumpReports(r.report)
+	reportoutput.DumpReports(r.Report)
 	return nil
 }

--- a/pkg/transform/report_output.go
+++ b/pkg/transform/report_output.go
@@ -1,106 +1,23 @@
 package transform
 
 import (
-	"encoding/json"
-
-	"github.com/fusor/cpma/pkg/io"
-	"github.com/fusor/cpma/pkg/transform/cluster"
+	"github.com/fusor/cpma/pkg/transform/reportoutput"
 	"github.com/sirupsen/logrus"
 )
 
-// ReportOutput holds a collection of reports to be written to file
-type ReportOutput struct {
-	ClusterReport    cluster.Report    `json:"cluster,omitempty"`
-	ComponentReports []ComponentReport `json:"components,omitempty"`
-}
-
-// ComponentReport holds a collection of ocp3 config reports
-type ComponentReport struct {
-	Component string   `json:"component"`
-	Reports   []Report `json:"reports"`
-}
-
-// ReportOutputFlush flush reports to disk
-var ReportOutputFlush = func(r ReportOutput) error {
-	logrus.Info("Flushing reports to disk")
-	DumpReports(r)
-	return nil
+// Report represents structure for final output
+type Report struct {
+	report reportoutput.ReportOutput
 }
 
 // Flush reports to files
-func (r ReportOutput) Flush() error {
+func (r Report) Flush() error {
 	return ReportOutputFlush(r)
 }
 
-// DumpReports creates OCDs files
-func DumpReports(r ReportOutput) {
-	var existingReports ReportOutput
-
-	jsonFile := "report.json"
-
-	jsonData, err := io.ReadFile(jsonFile)
-	if err != nil {
-		logrus.Errorf("unable to read to report file: %s", jsonFile)
-	}
-
-	if err := json.Unmarshal(jsonData, &existingReports); err != nil {
-		logrus.Errorf("unable to unmarshal existing report json")
-	}
-
-	for _, quota := range r.ClusterReport.Quotas {
-		existingReports.ClusterReport.Quotas = append(existingReports.ClusterReport.Quotas, quota)
-	}
-
-	for _, node := range r.ClusterReport.Nodes {
-		existingReports.ClusterReport.Nodes = append(existingReports.ClusterReport.Nodes, node)
-	}
-
-	for _, namespace := range r.ClusterReport.Namespaces {
-		existingReports.ClusterReport.Namespaces = append(existingReports.ClusterReport.Namespaces, namespace)
-	}
-
-	for _, pv := range r.ClusterReport.PVs {
-		existingReports.ClusterReport.PVs = append(existingReports.ClusterReport.PVs, pv)
-	}
-
-	for _, sc := range r.ClusterReport.StorageClasses {
-		existingReports.ClusterReport.StorageClasses = append(existingReports.ClusterReport.StorageClasses, sc)
-	}
-
-	for _, users := range r.ClusterReport.RBACReport.Users {
-		existingReports.ClusterReport.RBACReport.Users = append(existingReports.ClusterReport.RBACReport.Users, users)
-	}
-
-	for _, groups := range r.ClusterReport.RBACReport.Groups {
-		existingReports.ClusterReport.RBACReport.Groups = append(existingReports.ClusterReport.RBACReport.Groups, groups)
-	}
-
-	for _, roles := range r.ClusterReport.RBACReport.Roles {
-		existingReports.ClusterReport.RBACReport.Roles = append(existingReports.ClusterReport.RBACReport.Roles, roles)
-	}
-
-	for _, clusterRoles := range r.ClusterReport.RBACReport.ClusterRoles {
-		existingReports.ClusterReport.RBACReport.ClusterRoles = append(existingReports.ClusterReport.RBACReport.ClusterRoles, clusterRoles)
-	}
-
-	for _, clusterRoles := range r.ClusterReport.RBACReport.ClusterRoleBinding {
-		existingReports.ClusterReport.RBACReport.ClusterRoleBinding = append(existingReports.ClusterReport.RBACReport.ClusterRoleBinding, clusterRoles)
-	}
-
-	for _, scc := range r.ClusterReport.RBACReport.SecurityContextConstraints {
-		existingReports.ClusterReport.RBACReport.SecurityContextConstraints = append(existingReports.ClusterReport.RBACReport.SecurityContextConstraints, scc)
-	}
-
-	for _, componentReport := range r.ComponentReports {
-		existingReports.ComponentReports = append(existingReports.ComponentReports, componentReport)
-	}
-
-	jsonReports, err := json.MarshalIndent(existingReports, "", " ")
-	if err != nil {
-		logrus.Errorf("unable to marshal reports")
-	}
-
-	if err := io.WriteFile(jsonReports, jsonFile); err != nil {
-		logrus.Errorf("unable to write to report file: %s", jsonFile)
-	}
+// ReportOutputFlush flush reports to disk
+var ReportOutputFlush = func(r Report) error {
+	logrus.Info("Flushing reports to disk")
+	reportoutput.DumpReports(r.report)
+	return nil
 }

--- a/pkg/transform/reportoutput/html.go
+++ b/pkg/transform/reportoutput/html.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fusor/cpma/pkg/transform/reportoutput/templates"
 )
 
-var htmlTemplate = template.Must(template.New("html").Parse(templates.ReportHTML))
+
 
 // Output reads report stucture, generates html using go templates and writes it to a file
 func htmlOutput(report ReportOutput) error {
@@ -21,6 +21,8 @@ func htmlOutput(report ReportOutput) error {
 	if err != nil {
 		return err
 	}
+
+	htmlTemplate := template.Must(template.New("html").Parse(templates.ReportHTML))
 
 	err = htmlTemplate.Execute(f, report)
 	if err != nil {

--- a/pkg/transform/reportoutput/html.go
+++ b/pkg/transform/reportoutput/html.go
@@ -1,0 +1,31 @@
+package reportoutput
+
+import (
+	"html/template"
+	"os"
+	"path/filepath"
+
+	"github.com/fusor/cpma/pkg/env"
+	"github.com/fusor/cpma/pkg/transform/reportoutput/templates"
+)
+
+var htmlTemplate = template.Must(template.New("html").Parse(templates.ReportHTML))
+
+// Output reads report stucture, generates html using go templates and writes it to a file
+func htmlOutput(report ReportOutput) error {
+	path := filepath.Join(env.Config().GetString("WorkDir"), "report.html")
+
+	f, err := os.Create(path)
+	defer f.Close()
+
+	if err != nil {
+		return err
+	}
+
+	err = htmlTemplate.Execute(f, report)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/transform/reportoutput/html.go
+++ b/pkg/transform/reportoutput/html.go
@@ -9,8 +9,6 @@ import (
 	"github.com/fusor/cpma/pkg/transform/reportoutput/templates"
 )
 
-
-
 // Output reads report stucture, generates html using go templates and writes it to a file
 func htmlOutput(report ReportOutput) error {
 	path := filepath.Join(env.Config().GetString("WorkDir"), "report.html")

--- a/pkg/transform/reportoutput/json.go
+++ b/pkg/transform/reportoutput/json.go
@@ -1,0 +1,87 @@
+package reportoutput
+
+import (
+	"encoding/json"
+
+	"github.com/fusor/cpma/pkg/io"
+	"github.com/pkg/errors"
+)
+
+func jsonOutput(r ReportOutput) error {
+	var existingReports ReportOutput
+
+	jsonFile := "report.json"
+	emptyReport := []byte("{}")
+
+	if err := io.WriteFile(emptyReport, jsonFile); err != nil {
+		return errors.Wrapf(err, "unable to open report file: %s", jsonFile)
+	}
+
+	jsonData, err := io.ReadFile(jsonFile)
+	if err != nil {
+		return errors.Wrapf(err, "unable to read to report file: %s", jsonFile)
+	}
+
+	if err := json.Unmarshal(jsonData, &existingReports); err != nil {
+		return errors.Wrap(err, "unable to unmarshal existing report json")
+	}
+
+	for _, quota := range r.ClusterReport.Quotas {
+		existingReports.ClusterReport.Quotas = append(existingReports.ClusterReport.Quotas, quota)
+	}
+
+	for _, node := range r.ClusterReport.Nodes {
+		existingReports.ClusterReport.Nodes = append(existingReports.ClusterReport.Nodes, node)
+	}
+
+	for _, namespace := range r.ClusterReport.Namespaces {
+		existingReports.ClusterReport.Namespaces = append(existingReports.ClusterReport.Namespaces, namespace)
+	}
+
+	for _, pv := range r.ClusterReport.PVs {
+		existingReports.ClusterReport.PVs = append(existingReports.ClusterReport.PVs, pv)
+	}
+
+	for _, sc := range r.ClusterReport.StorageClasses {
+		existingReports.ClusterReport.StorageClasses = append(existingReports.ClusterReport.StorageClasses, sc)
+	}
+
+	for _, users := range r.ClusterReport.RBACReport.Users {
+		existingReports.ClusterReport.RBACReport.Users = append(existingReports.ClusterReport.RBACReport.Users, users)
+	}
+
+	for _, groups := range r.ClusterReport.RBACReport.Groups {
+		existingReports.ClusterReport.RBACReport.Groups = append(existingReports.ClusterReport.RBACReport.Groups, groups)
+	}
+
+	for _, roles := range r.ClusterReport.RBACReport.Roles {
+		existingReports.ClusterReport.RBACReport.Roles = append(existingReports.ClusterReport.RBACReport.Roles, roles)
+	}
+
+	for _, clusterRoles := range r.ClusterReport.RBACReport.ClusterRoles {
+		existingReports.ClusterReport.RBACReport.ClusterRoles = append(existingReports.ClusterReport.RBACReport.ClusterRoles, clusterRoles)
+	}
+
+	for _, clusterRoles := range r.ClusterReport.RBACReport.ClusterRoleBinding {
+		existingReports.ClusterReport.RBACReport.ClusterRoleBinding = append(existingReports.ClusterReport.RBACReport.ClusterRoleBinding, clusterRoles)
+	}
+
+	for _, scc := range r.ClusterReport.RBACReport.SecurityContextConstraints {
+		existingReports.ClusterReport.RBACReport.SecurityContextConstraints = append(existingReports.ClusterReport.RBACReport.SecurityContextConstraints, scc)
+	}
+
+	for _, componentReport := range r.ComponentReports {
+		existingReports.ComponentReports = append(existingReports.ComponentReports, componentReport)
+	}
+
+	jsonReports, err := json.MarshalIndent(existingReports, "", " ")
+	if err != nil {
+		return errors.Wrap(err, "unable to marshal reports")
+	}
+
+	if err := io.WriteFile(jsonReports, jsonFile); err != nil {
+		return errors.Wrapf(err, "unable to write to report file: %s", jsonFile)
+	}
+
+	return nil
+}

--- a/pkg/transform/reportoutput/json.go
+++ b/pkg/transform/reportoutput/json.go
@@ -8,73 +8,9 @@ import (
 )
 
 func jsonOutput(r ReportOutput) error {
-	var existingReports ReportOutput
-
 	jsonFile := "report.json"
-	emptyReport := []byte("{}")
 
-	if err := io.WriteFile(emptyReport, jsonFile); err != nil {
-		return errors.Wrapf(err, "unable to open report file: %s", jsonFile)
-	}
-
-	jsonData, err := io.ReadFile(jsonFile)
-	if err != nil {
-		return errors.Wrapf(err, "unable to read to report file: %s", jsonFile)
-	}
-
-	if err := json.Unmarshal(jsonData, &existingReports); err != nil {
-		return errors.Wrap(err, "unable to unmarshal existing report json")
-	}
-
-	for _, quota := range r.ClusterReport.Quotas {
-		existingReports.ClusterReport.Quotas = append(existingReports.ClusterReport.Quotas, quota)
-	}
-
-	for _, node := range r.ClusterReport.Nodes {
-		existingReports.ClusterReport.Nodes = append(existingReports.ClusterReport.Nodes, node)
-	}
-
-	for _, namespace := range r.ClusterReport.Namespaces {
-		existingReports.ClusterReport.Namespaces = append(existingReports.ClusterReport.Namespaces, namespace)
-	}
-
-	for _, pv := range r.ClusterReport.PVs {
-		existingReports.ClusterReport.PVs = append(existingReports.ClusterReport.PVs, pv)
-	}
-
-	for _, sc := range r.ClusterReport.StorageClasses {
-		existingReports.ClusterReport.StorageClasses = append(existingReports.ClusterReport.StorageClasses, sc)
-	}
-
-	for _, users := range r.ClusterReport.RBACReport.Users {
-		existingReports.ClusterReport.RBACReport.Users = append(existingReports.ClusterReport.RBACReport.Users, users)
-	}
-
-	for _, groups := range r.ClusterReport.RBACReport.Groups {
-		existingReports.ClusterReport.RBACReport.Groups = append(existingReports.ClusterReport.RBACReport.Groups, groups)
-	}
-
-	for _, roles := range r.ClusterReport.RBACReport.Roles {
-		existingReports.ClusterReport.RBACReport.Roles = append(existingReports.ClusterReport.RBACReport.Roles, roles)
-	}
-
-	for _, clusterRoles := range r.ClusterReport.RBACReport.ClusterRoles {
-		existingReports.ClusterReport.RBACReport.ClusterRoles = append(existingReports.ClusterReport.RBACReport.ClusterRoles, clusterRoles)
-	}
-
-	for _, clusterRoles := range r.ClusterReport.RBACReport.ClusterRoleBinding {
-		existingReports.ClusterReport.RBACReport.ClusterRoleBinding = append(existingReports.ClusterReport.RBACReport.ClusterRoleBinding, clusterRoles)
-	}
-
-	for _, scc := range r.ClusterReport.RBACReport.SecurityContextConstraints {
-		existingReports.ClusterReport.RBACReport.SecurityContextConstraints = append(existingReports.ClusterReport.RBACReport.SecurityContextConstraints, scc)
-	}
-
-	for _, componentReport := range r.ComponentReports {
-		existingReports.ComponentReports = append(existingReports.ComponentReports, componentReport)
-	}
-
-	jsonReports, err := json.MarshalIndent(existingReports, "", " ")
+	jsonReports, err := json.MarshalIndent(r, "", " ")
 	if err != nil {
 		return errors.Wrap(err, "unable to marshal reports")
 	}

--- a/pkg/transform/reportoutput/output.go
+++ b/pkg/transform/reportoutput/output.go
@@ -1,0 +1,108 @@
+package reportoutput
+
+import (
+	"encoding/json"
+
+	"github.com/fusor/cpma/pkg/io"
+	"github.com/fusor/cpma/pkg/transform/cluster"
+	"github.com/sirupsen/logrus"
+)
+
+// ReportOutput holds a collection of reports to be written to file
+type ReportOutput struct {
+	ClusterReport    cluster.Report    `json:"cluster,omitempty"`
+	ComponentReports []ComponentReport `json:"components,omitempty"`
+}
+
+// ComponentReport holds a collection of ocp3 config reports
+type ComponentReport struct {
+	Component string   `json:"component"`
+	Reports   []Report `json:"reports"`
+}
+
+// Report of OCP 4 component configuration compatibility
+type Report struct {
+	Name       string `json:"name"`
+	Kind       string `json:"kind"`
+	Supported  bool   `json:"supported"`
+	Confidence int    `json:"confidence"`
+	Comment    string `json:"comment"`
+}
+
+// DumpReports creates OCDs files
+func DumpReports(r ReportOutput) {
+	var existingReports ReportOutput
+
+	jsonFile := "report.json"
+	emptyReport := []byte("{}")
+
+	if err := io.WriteFile(emptyReport, jsonFile); err != nil {
+		logrus.Errorf("unable to open report file: %s", jsonFile)
+	}
+
+	jsonData, err := io.ReadFile(jsonFile)
+	if err != nil {
+		logrus.Errorf("unable to read to report file: %s", jsonFile)
+	}
+
+	if err := json.Unmarshal(jsonData, &existingReports); err != nil {
+		logrus.Errorf("unable to unmarshal existing report json")
+	}
+
+	for _, quota := range r.ClusterReport.Quotas {
+		existingReports.ClusterReport.Quotas = append(existingReports.ClusterReport.Quotas, quota)
+	}
+
+	for _, node := range r.ClusterReport.Nodes {
+		existingReports.ClusterReport.Nodes = append(existingReports.ClusterReport.Nodes, node)
+	}
+
+	for _, namespace := range r.ClusterReport.Namespaces {
+		existingReports.ClusterReport.Namespaces = append(existingReports.ClusterReport.Namespaces, namespace)
+	}
+
+	for _, pv := range r.ClusterReport.PVs {
+		existingReports.ClusterReport.PVs = append(existingReports.ClusterReport.PVs, pv)
+	}
+
+	for _, sc := range r.ClusterReport.StorageClasses {
+		existingReports.ClusterReport.StorageClasses = append(existingReports.ClusterReport.StorageClasses, sc)
+	}
+
+	for _, users := range r.ClusterReport.RBACReport.Users {
+		existingReports.ClusterReport.RBACReport.Users = append(existingReports.ClusterReport.RBACReport.Users, users)
+	}
+
+	for _, groups := range r.ClusterReport.RBACReport.Groups {
+		existingReports.ClusterReport.RBACReport.Groups = append(existingReports.ClusterReport.RBACReport.Groups, groups)
+	}
+
+	for _, roles := range r.ClusterReport.RBACReport.Roles {
+		existingReports.ClusterReport.RBACReport.Roles = append(existingReports.ClusterReport.RBACReport.Roles, roles)
+	}
+
+	for _, clusterRoles := range r.ClusterReport.RBACReport.ClusterRoles {
+		existingReports.ClusterReport.RBACReport.ClusterRoles = append(existingReports.ClusterReport.RBACReport.ClusterRoles, clusterRoles)
+	}
+
+	for _, clusterRoles := range r.ClusterReport.RBACReport.ClusterRoleBinding {
+		existingReports.ClusterReport.RBACReport.ClusterRoleBinding = append(existingReports.ClusterReport.RBACReport.ClusterRoleBinding, clusterRoles)
+	}
+
+	for _, scc := range r.ClusterReport.RBACReport.SecurityContextConstraints {
+		existingReports.ClusterReport.RBACReport.SecurityContextConstraints = append(existingReports.ClusterReport.RBACReport.SecurityContextConstraints, scc)
+	}
+
+	for _, componentReport := range r.ComponentReports {
+		existingReports.ComponentReports = append(existingReports.ComponentReports, componentReport)
+	}
+
+	jsonReports, err := json.MarshalIndent(existingReports, "", " ")
+	if err != nil {
+		logrus.Errorf("unable to marshal reports")
+	}
+
+	if err := io.WriteFile(jsonReports, jsonFile); err != nil {
+		logrus.Errorf("unable to write to report file: %s", jsonFile)
+	}
+}

--- a/pkg/transform/reportoutput/output.go
+++ b/pkg/transform/reportoutput/output.go
@@ -1,9 +1,6 @@
 package reportoutput
 
 import (
-	"encoding/json"
-
-	"github.com/fusor/cpma/pkg/io"
 	"github.com/fusor/cpma/pkg/transform/cluster"
 	"github.com/sirupsen/logrus"
 )
@@ -31,78 +28,18 @@ type Report struct {
 
 // DumpReports creates OCDs files
 func DumpReports(r ReportOutput) {
-	var existingReports ReportOutput
+	// reportOutputFormat := env.Config().GetString("OutputFormat")
+	reportOutputFormat := "all"
 
-	jsonFile := "report.json"
-	emptyReport := []byte("{}")
-
-	if err := io.WriteFile(emptyReport, jsonFile); err != nil {
-		logrus.Errorf("unable to open report file: %s", jsonFile)
-	}
-
-	jsonData, err := io.ReadFile(jsonFile)
-	if err != nil {
-		logrus.Errorf("unable to read to report file: %s", jsonFile)
-	}
-
-	if err := json.Unmarshal(jsonData, &existingReports); err != nil {
-		logrus.Errorf("unable to unmarshal existing report json")
-	}
-
-	for _, quota := range r.ClusterReport.Quotas {
-		existingReports.ClusterReport.Quotas = append(existingReports.ClusterReport.Quotas, quota)
-	}
-
-	for _, node := range r.ClusterReport.Nodes {
-		existingReports.ClusterReport.Nodes = append(existingReports.ClusterReport.Nodes, node)
-	}
-
-	for _, namespace := range r.ClusterReport.Namespaces {
-		existingReports.ClusterReport.Namespaces = append(existingReports.ClusterReport.Namespaces, namespace)
-	}
-
-	for _, pv := range r.ClusterReport.PVs {
-		existingReports.ClusterReport.PVs = append(existingReports.ClusterReport.PVs, pv)
-	}
-
-	for _, sc := range r.ClusterReport.StorageClasses {
-		existingReports.ClusterReport.StorageClasses = append(existingReports.ClusterReport.StorageClasses, sc)
-	}
-
-	for _, users := range r.ClusterReport.RBACReport.Users {
-		existingReports.ClusterReport.RBACReport.Users = append(existingReports.ClusterReport.RBACReport.Users, users)
-	}
-
-	for _, groups := range r.ClusterReport.RBACReport.Groups {
-		existingReports.ClusterReport.RBACReport.Groups = append(existingReports.ClusterReport.RBACReport.Groups, groups)
-	}
-
-	for _, roles := range r.ClusterReport.RBACReport.Roles {
-		existingReports.ClusterReport.RBACReport.Roles = append(existingReports.ClusterReport.RBACReport.Roles, roles)
-	}
-
-	for _, clusterRoles := range r.ClusterReport.RBACReport.ClusterRoles {
-		existingReports.ClusterReport.RBACReport.ClusterRoles = append(existingReports.ClusterReport.RBACReport.ClusterRoles, clusterRoles)
-	}
-
-	for _, clusterRoles := range r.ClusterReport.RBACReport.ClusterRoleBinding {
-		existingReports.ClusterReport.RBACReport.ClusterRoleBinding = append(existingReports.ClusterReport.RBACReport.ClusterRoleBinding, clusterRoles)
-	}
-
-	for _, scc := range r.ClusterReport.RBACReport.SecurityContextConstraints {
-		existingReports.ClusterReport.RBACReport.SecurityContextConstraints = append(existingReports.ClusterReport.RBACReport.SecurityContextConstraints, scc)
-	}
-
-	for _, componentReport := range r.ComponentReports {
-		existingReports.ComponentReports = append(existingReports.ComponentReports, componentReport)
-	}
-
-	jsonReports, err := json.MarshalIndent(existingReports, "", " ")
-	if err != nil {
-		logrus.Errorf("unable to marshal reports")
-	}
-
-	if err := io.WriteFile(jsonReports, jsonFile); err != nil {
-		logrus.Errorf("unable to write to report file: %s", jsonFile)
+	switch reportOutputFormat {
+	case "json":
+		jsonOutput(r)
+	case "html":
+		htmlOutput(r)
+	case "all":
+		jsonOutput(r)
+		htmlOutput(r)
+	default:
+		logrus.Error("This format type is not supported")
 	}
 }

--- a/pkg/transform/reportoutput/templates/report_template.go
+++ b/pkg/transform/reportoutput/templates/report_template.go
@@ -1,0 +1,18 @@
+package templates
+
+// ReportHTML represents main template
+const ReportHTML = `
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+		<title>CPMA report</title>
+		<style>
+		</style>
+	</head>
+	<body>
+	</body>
+	<script>
+	</script>
+</html>
+`

--- a/pkg/transform/scheduler_transform.go
+++ b/pkg/transform/scheduler_transform.go
@@ -4,6 +4,7 @@ import (
 	"github.com/fusor/cpma/pkg/decode"
 	"github.com/fusor/cpma/pkg/env"
 	"github.com/fusor/cpma/pkg/io"
+	"github.com/fusor/cpma/pkg/transform/reportoutput"
 	"github.com/fusor/cpma/pkg/transform/scheduler"
 	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	"github.com/sirupsen/logrus"
@@ -36,11 +37,7 @@ func (e SchedulerExtraction) Transform() ([]Output, error) {
 
 	if env.Config().GetBool("Reporting") {
 		logrus.Info("SchedulerTransform::Transform:Reports")
-		reports, err := e.buildReportOutput()
-		if err != nil {
-			return nil, err
-		}
-		outputs = append(outputs, reports)
+		e.buildReportOutput()
 	}
 
 	return outputs, nil
@@ -67,13 +64,13 @@ func (e SchedulerExtraction) buildManifestOutput() (Output, error) {
 	}, nil
 }
 
-func (e SchedulerExtraction) buildReportOutput() (Output, error) {
-	componentReport := ComponentReport{
+func (e SchedulerExtraction) buildReportOutput() {
+	componentReport := reportoutput.ComponentReport{
 		Component: SchedulerComponentName,
 	}
 
 	componentReport.Reports = append(componentReport.Reports,
-		Report{
+		reportoutput.Report{
 			Name:       "DefaultNodeSelector",
 			Kind:       "ProjectConfig",
 			Supported:  true,
@@ -81,11 +78,7 @@ func (e SchedulerExtraction) buildReportOutput() (Output, error) {
 			Comment:    "",
 		})
 
-	reportOutput := ReportOutput{
-		ComponentReports: []ComponentReport{componentReport},
-	}
-
-	return reportOutput, nil
+	finalReportOutput.report.ComponentReports = append(finalReportOutput.report.ComponentReports, componentReport)
 }
 
 // Extract collects Scheduler configuration information from an OCP3 cluster

--- a/pkg/transform/scheduler_transform.go
+++ b/pkg/transform/scheduler_transform.go
@@ -78,7 +78,7 @@ func (e SchedulerExtraction) buildReportOutput() {
 			Comment:    "",
 		})
 
-	finalReportOutput.report.ComponentReports = append(finalReportOutput.report.ComponentReports, componentReport)
+	FinalReportOutput.Report.ComponentReports = append(FinalReportOutput.Report.ComponentReports, componentReport)
 }
 
 // Extract collects Scheduler configuration information from an OCP3 cluster

--- a/pkg/transform/scheduler_transform_test.go
+++ b/pkg/transform/scheduler_transform_test.go
@@ -6,8 +6,10 @@ import (
 	"testing"
 
 	"github.com/fusor/cpma/pkg/decode"
+	"github.com/fusor/cpma/pkg/env"
 	"github.com/fusor/cpma/pkg/io"
 	"github.com/fusor/cpma/pkg/transform"
+	"github.com/fusor/cpma/pkg/transform/reportoutput"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -31,7 +33,7 @@ func TestSchedulerExtractionTransform(t *testing.T) {
 	expectedManifests = append(expectedManifests,
 		transform.Manifest{Name: "100_CPMA-cluster-config-scheduler.yaml", CRD: expectedSchedulerCRYAML})
 
-	expectedReport := transform.ReportOutput{}
+	expectedReport := reportoutput.ReportOutput{}
 	jsonData, err := io.ReadFile("testdata/expected-report-scheduler.json")
 	require.NoError(t, err)
 
@@ -41,7 +43,7 @@ func TestSchedulerExtractionTransform(t *testing.T) {
 	testCases := []struct {
 		name              string
 		expectedManifests []transform.Manifest
-		expectedReports   transform.ReportOutput
+		expectedReports   reportoutput.ReportOutput
 	}{
 		{
 			name:              "transform project extraction",
@@ -53,15 +55,16 @@ func TestSchedulerExtractionTransform(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			actualManifestsChan := make(chan []transform.Manifest)
-			actualReportsChan := make(chan transform.ReportOutput)
+			actualReportsChan := make(chan reportoutput.ReportOutput)
+			transform.FinalReportOutput = transform.Report{}
 
 			// Override flush method
 			transform.ManifestOutputFlush = func(manifests []transform.Manifest) error {
 				actualManifestsChan <- manifests
 				return nil
 			}
-			transform.ReportOutputFlush = func(reports transform.ReportOutput) error {
-				actualReportsChan <- reports
+			transform.ReportOutputFlush = func(reports transform.Report) error {
+				actualReportsChan <- reports.Report
 				return nil
 			}
 
@@ -69,6 +72,9 @@ func TestSchedulerExtractionTransform(t *testing.T) {
 			require.NoError(t, err)
 
 			go func() {
+				env.Config().Set("Reporting", true)
+				env.Config().Set("Manifests", true)
+
 				transformOutput, err := testExtraction.Transform()
 				if err != nil {
 					t.Error(err)
@@ -76,12 +82,13 @@ func TestSchedulerExtractionTransform(t *testing.T) {
 				for _, output := range transformOutput {
 					output.Flush()
 				}
+				transform.FinalReportOutput.Flush()
 			}()
 
 			actualManifests := <-actualManifestsChan
 			assert.Equal(t, actualManifests, tc.expectedManifests)
 			actualReports := <-actualReportsChan
-			assert.Equal(t, actualReports, tc.expectedReports)
+			assert.Equal(t, actualReports.ComponentReports, tc.expectedReports.ComponentReports)
 		})
 	}
 }

--- a/pkg/transform/sdn_transform.go
+++ b/pkg/transform/sdn_transform.go
@@ -120,7 +120,7 @@ func (e SDNExtraction) buildReportOutput() {
 			Comment:    "Translation of this configuration is not supported, refer to ingress operator configuration for more information",
 		})
 
-	finalReportOutput.report.ComponentReports = append(finalReportOutput.report.ComponentReports, componentReport)
+	FinalReportOutput.Report.ComponentReports = append(FinalReportOutput.Report.ComponentReports, componentReport)
 }
 
 // Extract collects SDN configuration information from an OCP3 cluster

--- a/pkg/transform/sdn_transform.go
+++ b/pkg/transform/sdn_transform.go
@@ -2,10 +2,10 @@ package transform
 
 import (
 	"fmt"
-
 	"github.com/fusor/cpma/pkg/decode"
 	"github.com/fusor/cpma/pkg/env"
 	"github.com/fusor/cpma/pkg/io"
+	"github.com/fusor/cpma/pkg/transform/reportoutput"
 	"github.com/fusor/cpma/pkg/transform/sdn"
 	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	"github.com/sirupsen/logrus"
@@ -41,11 +41,7 @@ func (e SDNExtraction) Transform() ([]Output, error) {
 
 	if env.Config().GetBool("Reporting") {
 		logrus.Info("SDNTransform::Transform:Reports")
-		reports, err := e.buildReportOutput()
-		if err != nil {
-			return nil, err
-		}
-		outputs = append(outputs, reports)
+		e.buildReportOutput()
 	}
 
 	return outputs, nil
@@ -71,15 +67,15 @@ func (e SDNExtraction) buildManifestOutput() (Output, error) {
 	}, nil
 }
 
-func (e SDNExtraction) buildReportOutput() (Output, error) {
-	componentReport := ComponentReport{
+func (e SDNExtraction) buildReportOutput() {
+	componentReport := reportoutput.ComponentReport{
 		Component: SDNComponentName,
 	}
 
 	for _, n := range e.MasterConfig.NetworkConfig.ClusterNetworks {
 		cidrComment := fmt.Sprintf("Networks must be configured during installation, it's possible to use %s", n.CIDR)
 		componentReport.Reports = append(componentReport.Reports,
-			Report{
+			reportoutput.Report{
 				Name:       "CIDR",
 				Kind:       "ClusterNetwork",
 				Supported:  true,
@@ -88,7 +84,7 @@ func (e SDNExtraction) buildReportOutput() (Output, error) {
 			})
 
 		componentReport.Reports = append(componentReport.Reports,
-			Report{
+			reportoutput.Report{
 				Name:       "HostSubnetLength",
 				Kind:       "ClusterNetwork",
 				Supported:  false,
@@ -98,7 +94,7 @@ func (e SDNExtraction) buildReportOutput() (Output, error) {
 	}
 
 	componentReport.Reports = append(componentReport.Reports,
-		Report{
+		reportoutput.Report{
 			Name:       e.MasterConfig.NetworkConfig.ServiceNetworkCIDR,
 			Kind:       "ServiceNetwork",
 			Supported:  true,
@@ -107,7 +103,7 @@ func (e SDNExtraction) buildReportOutput() (Output, error) {
 		})
 
 	componentReport.Reports = append(componentReport.Reports,
-		Report{
+		reportoutput.Report{
 			Name:       "",
 			Kind:       "ExternalIPNetworkCIDRs",
 			Supported:  false,
@@ -116,7 +112,7 @@ func (e SDNExtraction) buildReportOutput() (Output, error) {
 		})
 
 	componentReport.Reports = append(componentReport.Reports,
-		Report{
+		reportoutput.Report{
 			Name:       "",
 			Kind:       "IngressIPNetworkCIDR",
 			Supported:  false,
@@ -124,11 +120,7 @@ func (e SDNExtraction) buildReportOutput() (Output, error) {
 			Comment:    "Translation of this configuration is not supported, refer to ingress operator configuration for more information",
 		})
 
-	reportOutput := ReportOutput{
-		ComponentReports: []ComponentReport{componentReport},
-	}
-
-	return reportOutput, nil
+	finalReportOutput.report.ComponentReports = append(finalReportOutput.report.ComponentReports, componentReport)
 }
 
 // Extract collects SDN configuration information from an OCP3 cluster

--- a/pkg/transform/sdn_transform_test.go
+++ b/pkg/transform/sdn_transform_test.go
@@ -5,9 +5,11 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/fusor/cpma/pkg/env"
 	"github.com/fusor/cpma/pkg/io"
 	"github.com/fusor/cpma/pkg/transform"
 	cpmatest "github.com/fusor/cpma/pkg/transform/internal/test"
+	"github.com/fusor/cpma/pkg/transform/reportoutput"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -21,7 +23,7 @@ func TestSDNExtractionTransform(t *testing.T) {
 	expectedManifests = append(expectedManifests,
 		transform.Manifest{Name: "100_CPMA-cluster-config-sdn.yaml", CRD: expectedSDNCRYAML})
 
-	expectedReport := transform.ReportOutput{}
+	expectedReport := reportoutput.ReportOutput{}
 	jsonData, err := io.ReadFile("testdata/expected-report-sdn.json")
 	require.NoError(t, err)
 
@@ -31,7 +33,7 @@ func TestSDNExtractionTransform(t *testing.T) {
 	testCases := []struct {
 		name              string
 		expectedManifests []transform.Manifest
-		expectedReports   transform.ReportOutput
+		expectedReports   reportoutput.ReportOutput
 	}{
 		{
 			name:              "transform sdn extraction",
@@ -43,15 +45,16 @@ func TestSDNExtractionTransform(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			actualManifestsChan := make(chan []transform.Manifest)
-			actualReportsChan := make(chan transform.ReportOutput)
+			actualReportsChan := make(chan reportoutput.ReportOutput)
+			transform.FinalReportOutput = transform.Report{}
 
 			// Override flush method
 			transform.ManifestOutputFlush = func(manifests []transform.Manifest) error {
 				actualManifestsChan <- manifests
 				return nil
 			}
-			transform.ReportOutputFlush = func(reports transform.ReportOutput) error {
-				actualReportsChan <- reports
+			transform.ReportOutputFlush = func(reports transform.Report) error {
+				actualReportsChan <- reports.Report
 				return nil
 			}
 
@@ -59,6 +62,9 @@ func TestSDNExtractionTransform(t *testing.T) {
 			require.NoError(t, err)
 
 			go func() {
+				env.Config().Set("Reporting", true)
+				env.Config().Set("Manifests", true)
+
 				transformOutput, err := testExtraction.Transform()
 				if err != nil {
 					t.Error(err)
@@ -66,12 +72,13 @@ func TestSDNExtractionTransform(t *testing.T) {
 				for _, output := range transformOutput {
 					output.Flush()
 				}
+				transform.FinalReportOutput.Flush()
 			}()
 
 			actualManifests := <-actualManifestsChan
 			assert.Equal(t, actualManifests, tc.expectedManifests)
 			actualReports := <-actualReportsChan
-			assert.Equal(t, actualReports, tc.expectedReports)
+			assert.Equal(t, actualReports.ComponentReports, tc.expectedReports.ComponentReports)
 		})
 	}
 }

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -27,7 +27,8 @@ const (
 './openshift-install --dir $INSTALL_DIR  create cluster'`
 )
 
-var finalReportOutput Report
+// FinalReportOutput represents final output
+var FinalReportOutput Report
 
 // Cluster contains a cluster
 type Cluster struct {
@@ -122,7 +123,7 @@ func (r Runner) Transform(transforms []Transform) {
 		}
 	}
 
-	err := finalReportOutput.Flush()
+	err := FinalReportOutput.Flush()
 	if err != nil {
 		HandleError(err, "Report")
 	}

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -1,8 +1,6 @@
 package transform
 
 import (
-	"github.com/fusor/cpma/pkg/env"
-	"github.com/fusor/cpma/pkg/io"
 	"github.com/fusor/cpma/pkg/transform/configmaps"
 	"github.com/fusor/cpma/pkg/transform/secrets"
 	"github.com/ghodss/yaml"
@@ -29,6 +27,8 @@ const (
 './openshift-install --dir $INSTALL_DIR  create cluster'`
 )
 
+var finalReportOutput Report
+
 // Cluster contains a cluster
 type Cluster struct {
 	Master Master
@@ -45,15 +45,6 @@ type Master struct {
 type Manifest struct {
 	Name string
 	CRD  []byte
-}
-
-// Report of OCP 4 component configuration compatibility
-type Report struct {
-	Name       string `json:"name"`
-	Kind       string `json:"kind"`
-	Supported  bool   `json:"supported"`
-	Confidence int    `json:"confidence"`
-	Comment    string `json:"comment"`
 }
 
 // Runner a generic transform runner
@@ -80,8 +71,6 @@ type Output interface {
 //Start generating manifests to be used with Openshift 4
 func Start() {
 	runner := NewRunner()
-
-	openReports()
 
 	runner.Transform([]Transform{
 		APITransform{},
@@ -121,12 +110,21 @@ func (r Runner) Transform(transforms []Transform) {
 			HandleError(err, transform.Name())
 			continue
 		}
+
 		for _, output := range outputs {
-			if err := output.Flush(); err != nil {
-				HandleError(err, transform.Name())
-				continue
+			switch output.(type) {
+			case ManifestOutput:
+				if err := output.Flush(); err != nil {
+					HandleError(err, transform.Name())
+					continue
+				}
 			}
 		}
+	}
+
+	err := finalReportOutput.Flush()
+	if err != nil {
+		HandleError(err, "Report")
 	}
 }
 
@@ -149,15 +147,4 @@ func GenYAML(CR interface{}) ([]byte, error) {
 	}
 
 	return yamlBytes, nil
-}
-
-func openReports() {
-	if env.Config().GetBool("Reporting") {
-		jsonfile := "report.json"
-		emptyReport := []byte("{}")
-
-		if err := io.WriteFile(emptyReport, jsonfile); err != nil {
-			logrus.Errorf("unable to open report file: %s", jsonfile)
-		}
-	}
 }


### PR DESCRIPTION
Since we are in feature freeze PR will go to a separate branch for now.
After some discussion, we decided that will be nice to support multiple report output formats: json, html, maybe pdf in future etc. 

This PR introduces 3 things: 

1. Improvement of writing report to json file.
Our current process of writing report to json file creates a json file before the transforms starts and then opens the file and appends a new report for every config part we have, this means the json file is opened, unmarshalled, marshalled a lot of times. 
I refactored this part, now all reports are collected and final report is passed to output function, report json is created only in case when report format is set to json and file is opened only once.

2. Adds support for multiple output formats.
I added new package `reportoutput`. This package is responsible for different output formats. It is scalable and has very simple structure.

3. Initial steps on HTML report.
`html.go` in `reportoutput` will be handling html report format. It is using go templates and inspired by go cover tool - https://github.com/golang/tools/blob/master/cmd/cover/html.go#L195