### PR TITLE
Replace verbose with silent and improve logging

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,9 +85,9 @@ func init() {
 	rootCmd.PersistentFlags().Int16P("ssh-port", "p", 0, "OCP3 ssh port")
 	env.Config().BindPFlag("SSHPort", rootCmd.PersistentFlags().Lookup("ssh-port"))
 
-	// Output logs to console if true
-	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "verbose output")
-	env.Config().BindPFlag("Verbose", rootCmd.PersistentFlags().Lookup("verbose"))
+	// Don't output logs to console if true
+	rootCmd.PersistentFlags().BoolP("silent", "s", false, "silent output")
+	env.Config().BindPFlag("Silent", rootCmd.PersistentFlags().Lookup("silent"))
 
 	// Get config file from an save to viper config
 	rootCmd.PersistentFlags().StringP("work-dir", "w", "", "set application data working directory (Default \".\")")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -25,7 +25,7 @@ func TestInitDefaults(t *testing.T) {
 	assert.Equal(t, "", env.Config().GetString("SSHPrivateKey"))
 	assert.Equal(t, "", env.Config().GetString("SSHLogin"))
 	assert.Equal(t, "0", env.Config().GetString("SSHPort"))
-	assert.Equal(t, false, env.Config().Get("Verbose"))
+	assert.Equal(t, false, env.Config().Get("Silent"))
 	assert.Equal(t, "", env.Config().GetString("WorkDIr"))
 }
 

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -470,7 +470,7 @@ func InitLogger() {
 		ForceColors:     true,
 	}
 
-	if viperConfig.GetBool("verbose") {
+	if !viperConfig.GetBool("silent") {
 		stdoutHook := &ConsoleWriterHook{
 			Writer: os.Stdout,
 			LogLevels: []logrus.Level{

--- a/pkg/transform/cluster/cluster.go
+++ b/pkg/transform/cluster/cluster.go
@@ -243,7 +243,7 @@ func ReportDeployments(reportedNamespace *NamespaceReport, deploymentList *k8sap
 
 // ReportNamespaces fills in information about Namespaces
 func (clusterReport *Report) ReportNamespaces(apiResources api.Resources) {
-	logrus.Debug("ClusterReport::ReportNamespaces")
+	logrus.Info("ClusterReport::ReportNamespaces")
 
 	for _, resources := range apiResources.NamespaceList {
 		reportedNamespace := NamespaceReport{Name: resources.NamespaceName}
@@ -266,7 +266,7 @@ func (clusterReport *Report) ReportNamespaces(apiResources api.Resources) {
 
 // ReportNodes fills in information about nodes
 func (clusterReport *Report) ReportNodes(apiResources api.Resources) {
-	logrus.Debug("ClusterReport::ReportNodes")
+	logrus.Info("ClusterReport::ReportNodes")
 
 	for _, node := range apiResources.NodeList.Items {
 		nodeReport := NodeReport{
@@ -312,7 +312,7 @@ func ReportNodeResources(repotedNode *NodeReport, nodeStatus k8sapicore.NodeStat
 
 // ReportQuotas creates report about cluster quotas
 func (clusterReport *Report) ReportQuotas(apiResources api.Resources) {
-	logrus.Debug("ClusterReport::ReportQuotas")
+	logrus.Info("ClusterReport::ReportQuotas")
 
 	for _, quota := range apiResources.QuotaList.Items {
 		quotaReport := QuotaReport{
@@ -383,7 +383,7 @@ func ReportRoutes(reportedNamespace *NamespaceReport, routeList *o7tapiroute.Rou
 
 // ReportPVs create report oabout pvs
 func (clusterReport *Report) ReportPVs(apiResources api.Resources) {
-	logrus.Debug("ClusterReport::ReportPVs")
+	logrus.Info("ClusterReport::ReportPVs")
 	pvList := apiResources.PersistentVolumeList
 
 	// Go through all PV and save required information to report
@@ -436,7 +436,7 @@ func ReportPVCs(reporeportedNamespace *NamespaceReport, pvcList *k8scorev1.Persi
 
 // ReportRBAC create report about RBAC policy
 func (clusterReport *Report) ReportRBAC(apiResources api.Resources) {
-	logrus.Debug("ClusterReport::ReportRBAC")
+	logrus.Info("ClusterReport::ReportRBAC")
 
 	clusterReport.RBACReport.Users = make([]OpenshiftUser, 0)
 	for _, user := range apiResources.RBACResources.UsersList.Items {
@@ -546,7 +546,7 @@ func (clusterReport *Report) ReportRBAC(apiResources api.Resources) {
 
 // ReportStorageClasses create report about storage classes
 func (clusterReport *Report) ReportStorageClasses(apiResources api.Resources) {
-	logrus.Debug("ClusterReport::ReportStorageClasses")
+	logrus.Info("ClusterReport::ReportStorageClasses")
 	// Go through all storage classes and save required information to report
 	storageClassList := apiResources.StorageClassList
 	for _, storageClass := range storageClassList.Items {

--- a/pkg/transform/cluster_transform.go
+++ b/pkg/transform/cluster_transform.go
@@ -11,8 +11,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// ClusterReportName is the cluster report name
-const ClusterReportName = "ClusterReport"
+// ClusterTransformName is the cluster report name
+const ClusterTransformName = "Cluster"
 
 // ClusterExtraction holds data extracted from k8s API resources
 type ClusterExtraction struct {
@@ -208,5 +208,5 @@ func (e ClusterTransform) Extract() (Extraction, error) {
 
 // Name returns a human readable name for the transform
 func (e ClusterTransform) Name() string {
-	return ClusterReportName
+	return ClusterTransformName
 }

--- a/pkg/transform/oauth/oauth.go
+++ b/pkg/transform/oauth/oauth.go
@@ -119,7 +119,7 @@ func Translate(identityProviders []IdentityProvider, tokenConfig TokenConfig, te
 		case "BasicAuthPasswordIdentityProvider":
 			providerResources, err = buildBasicAuthIP(serializer, p)
 		default:
-			logrus.Infof("Can't handle %s OAuth kind", kind)
+			logrus.Warnf("Can't handle %s OAuth kind", kind)
 			continue
 		}
 

--- a/pkg/transform/reportoutput/html.go
+++ b/pkg/transform/reportoutput/html.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/fusor/cpma/pkg/env"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	k8sapicore "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -126,6 +127,8 @@ func parseTemplates() (*template.Template, error) {
 		}
 		htmlTemplate = template.Must(htmlTemplate.Parse(stringTemplate))
 	}
+
+	logrus.Infof("Report:Added: %s", htmlFileName)
 
 	return htmlTemplate, nil
 }

--- a/pkg/transform/reportoutput/json.go
+++ b/pkg/transform/reportoutput/json.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/fusor/cpma/pkg/io"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 func jsonOutput(r ReportOutput) {
@@ -16,4 +17,6 @@ func jsonOutput(r ReportOutput) {
 	if err := io.WriteFile(jsonReports, jsonFileName); err != nil {
 		panic(errors.Wrapf(err, "unable to write to report file: %s", jsonFileName))
 	}
+
+	logrus.Infof("Report:Added: %s", jsonFileName)
 }

--- a/pkg/transform/sdn_transform.go
+++ b/pkg/transform/sdn_transform.go
@@ -2,6 +2,7 @@ package transform
 
 import (
 	"fmt"
+
 	"github.com/fusor/cpma/pkg/decode"
 	"github.com/fusor/cpma/pkg/env"
 	"github.com/fusor/cpma/pkg/io"

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -71,6 +71,7 @@ type Output interface {
 
 //Start generating manifests to be used with Openshift 4
 func Start() {
+	logrus.Info("Starting manifest and report generation")
 	runner := NewRunner()
 
 	runner.Transform([]Transform{
@@ -88,13 +89,15 @@ func Start() {
 
 // Transform is the process run to complete a transform
 func (r Runner) Transform(transforms []Transform) {
-	logrus.Info("TransformRunner::Transform")
+	logrus.Debug("TransformRunner::Transform")
 
 	// For each transform, extract the data, validate it, and run the transform.
 	// Handle any errors, and finally flush the output to it's desired destination
 	// NOTE: This should be parallelized with channels unless the transforms have
 	// some dependency on the outputs of others
 	for _, transform := range transforms {
+		logrus.Infof("Transform:Starting for - %s", transform.Name())
+
 		extraction, err := transform.Extract()
 		if err != nil {
 			HandleError(err, transform.Name())
@@ -127,6 +130,8 @@ func (r Runner) Transform(transforms []Transform) {
 	if err != nil {
 		HandleError(err, "Report")
 	}
+
+	logrus.Info("Succesfully finished transformations")
 }
 
 // NewRunner creates a new Runner


### PR DESCRIPTION
This PR replaces `--verbose` with `--silent` and improves info warning log level.

Example of logs after this PR:
```
ademicev-OSX:cpma ademicev$./bin/cpma
INFO[27 Aug 19 09:33 CEST] Starting manifest and report generation
INFO[27 Aug 19 09:33 CEST] Finished transforming - API
INFO[27 Aug 19 09:33 CEST] Flushing manifests to disk
INFO[27 Aug 19 09:33 CEST] CRD:Added: data/manifests/100_CPMA-cluster-quota-resource-for-user.yaml
INFO[27 Aug 19 09:33 CEST] Finished transforming - ClusterReport
WARN[27 Aug 19 09:33 CEST] Skipping Crio: No configuration file available
INFO[27 Aug 19 09:33 CEST] Finished transforming - Docker
INFO[27 Aug 19 09:33 CEST] Finished transforming - ETCD
INFO[27 Aug 19 09:33 CEST] Flushing manifests to disk
INFO[27 Aug 19 09:33 CEST] CRD:Added: data/manifests/100_CPMA-cluster-config-oauth.yaml
INFO[27 Aug 19 09:33 CEST] CRD:Added: data/manifests/100_CPMA-cluster-config-secret-htpasswd-secret.yaml
INFO[27 Aug 19 09:33 CEST] Finished transforming - OAuth
INFO[27 Aug 19 09:33 CEST] Flushing manifests to disk
INFO[27 Aug 19 09:33 CEST] CRD:Added: data/manifests/100_CPMA-cluster-config-sdn.yaml
INFO[27 Aug 19 09:33 CEST] Finished transforming - SDN
INFO[27 Aug 19 09:33 CEST] Flushing manifests to disk
INFO[27 Aug 19 09:33 CEST] CRD:Added: data/manifests/100_CPMA-cluster-config-image.yaml
INFO[27 Aug 19 09:33 CEST] Finished transforming - Image
INFO[27 Aug 19 09:33 CEST] Flushing manifests to disk
INFO[27 Aug 19 09:33 CEST] CRD:Added: data/manifests/100_CPMA-cluster-config-project.yaml
INFO[27 Aug 19 09:33 CEST] Finished transforming - Project
INFO[27 Aug 19 09:33 CEST] Flushing reports to disk
INFO[27 Aug 19 09:33 CEST] Report:Added: report.json
INFO[27 Aug 19 09:33 CEST] Report:Added: report.html
INFO[27 Aug 19 09:33 CEST] Succesfully finished transformations
```