### PR TITLE
env_test: force debug and silent to false

### DIFF
--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -112,10 +112,12 @@ func TestInitFromEnv(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			os.Setenv("CPMA_CLUSTERNAME", "somename")
+			os.Setenv("CPMA_DEBUG", "false")
 			os.Setenv("CPMA_HOSTNAME", "master.example.org")
 			os.Setenv("CPMA_MANIFESTS", "true")
 			os.Setenv("CPMA_REPORTING", "true")
 			os.Setenv("CPMA_SAVECONFIG", "false")
+			os.Setenv("CPMA_SILENT", "false")
 			os.Setenv("CPMA_WORKDIR", "testdata/out")
 
 			os.Setenv("CPMA_CRIOCONFIGFILE", "/etc/crio/crio.conf")


### PR DESCRIPTION
Avoids side effects when running TestInitFromEnv.
InitConfig use default config (cpma.yaml) if available so we need to override all ENV variables.