### PR TITLE
Revert "OAuth GitHub Provider: Organizations or Teams field is mandatry (#389)"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,5 +43,3 @@ require (
 	k8s.io/utils v0.0.0-20190308190857-21c4ce38f2a7 // indirect
 	sigs.k8s.io/yaml v1.1.0 // indirect
 )
-
-go 1.13

--- a/pkg/transform/oauth/github.go
+++ b/pkg/transform/oauth/github.go
@@ -31,8 +31,8 @@ func buildGitHubIP(serializer *json.Serializer, p IdentityProvider) (*ProviderRe
 	idP.Name = p.Name
 	idP.MappingMethod = configv1.MappingMethodType(p.MappingMethod)
 	idP.GitHub = &configv1.GitHubIdentityProvider{}
-	idP.GitHub.ClientID = github.ClientID
 	idP.GitHub.Hostname = github.Hostname
+	idP.GitHub.ClientID = github.ClientID
 	idP.GitHub.Organizations = github.Organizations
 	idP.GitHub.Teams = github.Teams
 
@@ -84,10 +84,6 @@ func validateGithubProvider(serializer *json.Serializer, p IdentityProvider) err
 
 	if err := validateClientData(github.ClientID, github.ClientSecret); err != nil {
 		return err
-	}
-
-	if github.Hostname == "" && (len(github.Organizations) == 0 || len(github.Teams) == 0) {
-		return errors.New("GitHub (non enterprise) provider without organizations or teams field is not supported")
 	}
 
 	return nil


### PR DESCRIPTION
This reverts commit cc21ebc1a23637d556af031e0103046f0993ba7c.

If the fields are missing it will stop no only github provider transform but the whole OAuth.
To be replaced by a new patch.