### PR TITLE
OAuth Github: Mapping method is optional

### DIFF
--- a/pkg/transform/oauth/github.go
+++ b/pkg/transform/oauth/github.go
@@ -78,8 +78,10 @@ func validateGithubProvider(serializer *json.Serializer, p IdentityProvider) err
 		return errors.New("Name can't be empty")
 	}
 
-	if err := validateMappingMethod(p.MappingMethod); err != nil {
-		return err
+	if p.MappingMethod != "" {
+		if err := validateMappingMethod(p.MappingMethod); err != nil {
+			return err
+		}
 	}
 
 	if github.ClientSecret.KeyFile != "" {


### PR DESCRIPTION
MappingMethod is optional.
If missing, it will be automatically added with default "claim" value.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1753152