### PR TITLE
[Release-1.0] - Backport: Fix double encoding for oauth secrets (#406)

### DIFF
--- a/pkg/transform/oauth/basicauth.go
+++ b/pkg/transform/oauth/basicauth.go
@@ -1,8 +1,6 @@
 package oauth
 
 import (
-	"encoding/base64"
-
 	configv1 "github.com/openshift/api/config/v1"
 
 	"github.com/fusor/cpma/pkg/transform/configmaps"
@@ -43,8 +41,7 @@ func buildBasicAuthIP(serializer *json.Serializer, p IdentityProvider) (*Provide
 		certSecretName := "basicauth-client-cert-secret"
 		idP.BasicAuth.TLSClientCert.Name = certSecretName
 
-		encoded := base64.StdEncoding.EncodeToString(p.CrtData)
-		certSecret, err := secrets.GenSecret(certSecretName, encoded, OAuthNamespace, secrets.BasicAuthSecretType)
+		certSecret, err := secrets.GenSecret(certSecretName, p.CrtData, OAuthNamespace, secrets.BasicAuthSecretType)
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to generate cert secret for basic auth, see error")
 		}
@@ -53,8 +50,7 @@ func buildBasicAuthIP(serializer *json.Serializer, p IdentityProvider) (*Provide
 		keySecretName := "basicauth-client-key-secret"
 		idP.BasicAuth.TLSClientKey.Name = keySecretName
 
-		encoded = base64.StdEncoding.EncodeToString(p.KeyData)
-		keySecret, err := secrets.GenSecret(keySecretName, encoded, OAuthNamespace, secrets.BasicAuthSecretType)
+		keySecret, err := secrets.GenSecret(keySecretName, p.KeyData, OAuthNamespace, secrets.BasicAuthSecretType)
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to generate key secret for basic auth, see error")
 		}

--- a/pkg/transform/oauth/github.go
+++ b/pkg/transform/oauth/github.go
@@ -1,8 +1,6 @@
 package oauth
 
 import (
-	"encoding/base64"
-
 	"github.com/fusor/cpma/pkg/io"
 	"github.com/fusor/cpma/pkg/transform/configmaps"
 	"github.com/fusor/cpma/pkg/transform/secrets"
@@ -53,8 +51,7 @@ func buildGitHubIP(serializer *json.Serializer, p IdentityProvider) (*ProviderRe
 		return nil, errors.Wrap(err, "Failed to fetch client secret for for github, see error")
 	}
 
-	encoded := base64.StdEncoding.EncodeToString([]byte(secretContent))
-	secret, err := secrets.GenSecret(secretName, encoded, OAuthNamespace, secrets.LiteralSecretType)
+	secret, err := secrets.GenSecret(secretName, []byte(secretContent), OAuthNamespace, secrets.LiteralSecretType)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to generate client secret for for github, see error")
 	}

--- a/pkg/transform/oauth/gitlab.go
+++ b/pkg/transform/oauth/gitlab.go
@@ -1,8 +1,6 @@
 package oauth
 
 import (
-	"encoding/base64"
-
 	"github.com/fusor/cpma/pkg/io"
 	"github.com/fusor/cpma/pkg/transform/configmaps"
 	"github.com/fusor/cpma/pkg/transform/secrets"
@@ -47,8 +45,7 @@ func buildGitLabIP(serializer *json.Serializer, p IdentityProvider) (*ProviderRe
 		return nil, errors.Wrap(err, "Failed to fetch client secret for gitlab, see error")
 	}
 
-	encoded := base64.StdEncoding.EncodeToString([]byte(secretContent))
-	secret, err := secrets.GenSecret(secretName, encoded, OAuthNamespace, secrets.LiteralSecretType)
+	secret, err := secrets.GenSecret(secretName, []byte(secretContent), OAuthNamespace, secrets.LiteralSecretType)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to generate secret for gitlab, see error")
 	}

--- a/pkg/transform/oauth/google.go
+++ b/pkg/transform/oauth/google.go
@@ -1,8 +1,6 @@
 package oauth
 
 import (
-	"encoding/base64"
-
 	"github.com/fusor/cpma/pkg/io"
 	"github.com/fusor/cpma/pkg/transform/secrets"
 	configv1 "github.com/openshift/api/config/v1"
@@ -39,8 +37,7 @@ func buildGoogleIP(serializer *json.Serializer, p IdentityProvider) (*ProviderRe
 		return nil, errors.Wrap(err, "Failed to fetch client secret for google, see error")
 	}
 
-	encoded := base64.StdEncoding.EncodeToString([]byte(secretContent))
-	secret, err := secrets.GenSecret(secretName, encoded, OAuthNamespace, secrets.LiteralSecretType)
+	secret, err := secrets.GenSecret(secretName, []byte(secretContent), OAuthNamespace, secrets.LiteralSecretType)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to generate client secret for google, see error")
 	}

--- a/pkg/transform/oauth/htpasswd.go
+++ b/pkg/transform/oauth/htpasswd.go
@@ -1,8 +1,6 @@
 package oauth
 
 import (
-	"encoding/base64"
-
 	"github.com/fusor/cpma/pkg/transform/secrets"
 	configv1 "github.com/openshift/api/config/v1"
 	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
@@ -32,9 +30,7 @@ func buildHTPasswdIP(serializer *json.Serializer, p IdentityProvider) (*Provider
 	idP.HTPasswd = &configv1.HTPasswdIdentityProvider{}
 	idP.HTPasswd.FileData.Name = secretName
 
-	encoded := base64.StdEncoding.EncodeToString(p.HTFileData)
-
-	secret, err := secrets.GenSecret(secretName, encoded, OAuthNamespace, secrets.HtpasswdSecretType)
+	secret, err := secrets.GenSecret(secretName, p.HTFileData, OAuthNamespace, secrets.HtpasswdSecretType)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to generate secret for htpasswd, see error")
 	}

--- a/pkg/transform/oauth/keystone.go
+++ b/pkg/transform/oauth/keystone.go
@@ -1,8 +1,6 @@
 package oauth
 
 import (
-	"encoding/base64"
-
 	"github.com/fusor/cpma/pkg/transform/configmaps"
 	"github.com/fusor/cpma/pkg/transform/secrets"
 	configv1 "github.com/openshift/api/config/v1"
@@ -47,8 +45,7 @@ func buildKeystoneIP(serializer *json.Serializer, p IdentityProvider) (*Provider
 	if keystone.CertFile != "" {
 		certSecretName := "keystone-client-cert-secret"
 		idP.Keystone.TLSClientCert.Name = certSecretName
-		encoded := base64.StdEncoding.EncodeToString(p.CrtData)
-		certSecret, err := secrets.GenSecret(certSecretName, encoded, OAuthNamespace, secrets.KeystoneSecretType)
+		certSecret, err := secrets.GenSecret(certSecretName, p.CrtData, OAuthNamespace, secrets.KeystoneSecretType)
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to generate cert secret for keystone, see error")
 		}
@@ -56,8 +53,7 @@ func buildKeystoneIP(serializer *json.Serializer, p IdentityProvider) (*Provider
 
 		keySecretName := "keystone-client-key-secret"
 		idP.Keystone.TLSClientKey.Name = keySecretName
-		encoded = base64.StdEncoding.EncodeToString(p.KeyData)
-		keySecret, err := secrets.GenSecret(keySecretName, encoded, OAuthNamespace, secrets.KeystoneSecretType)
+		keySecret, err := secrets.GenSecret(keySecretName, p.KeyData, OAuthNamespace, secrets.KeystoneSecretType)
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to generate key secret for keystone, see error")
 		}

--- a/pkg/transform/oauth/openid.go
+++ b/pkg/transform/oauth/openid.go
@@ -1,8 +1,6 @@
 package oauth
 
 import (
-	"encoding/base64"
-
 	"github.com/fusor/cpma/pkg/io"
 	"github.com/fusor/cpma/pkg/transform/secrets"
 	configv1 "github.com/openshift/api/config/v1"
@@ -41,9 +39,7 @@ func buildOpenIDIP(serializer *json.Serializer, p IdentityProvider) (*ProviderRe
 		return nil, errors.Wrap(err, "Failed to fetch client secret for openID, see error")
 	}
 
-	encoded := base64.StdEncoding.EncodeToString([]byte(secretContent))
-
-	secret, err := secrets.GenSecret(secretName, encoded, OAuthNamespace, secrets.LiteralSecretType)
+	secret, err := secrets.GenSecret(secretName, []byte(secretContent), OAuthNamespace, secrets.LiteralSecretType)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to generate secret for openID, see error")
 	}

--- a/pkg/transform/oauth/templates.go
+++ b/pkg/transform/oauth/templates.go
@@ -1,8 +1,6 @@
 package oauth
 
 import (
-	"encoding/base64"
-
 	"github.com/fusor/cpma/pkg/transform/secrets"
 	configv1 "github.com/openshift/api/config/v1"
 	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
@@ -22,8 +20,7 @@ func translateTemplates(templates legacyconfigv1.OAuthTemplates) (*configv1.OAut
 	translatedTemplates := &configv1.OAuthTemplates{}
 
 	if templates.Login != "" {
-		encoded := base64.StdEncoding.EncodeToString([]byte(templates.Login))
-		secret, err := secrets.GenSecret(loginSecret, encoded, OAuthNamespace, secrets.LiteralSecretType)
+		secret, err := secrets.GenSecret(loginSecret, []byte(templates.Login), OAuthNamespace, secrets.LiteralSecretType)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -32,8 +29,7 @@ func translateTemplates(templates legacyconfigv1.OAuthTemplates) (*configv1.OAut
 	}
 
 	if templates.Error != "" {
-		encoded := base64.StdEncoding.EncodeToString([]byte(templates.Error))
-		secret, err := secrets.GenSecret(errorSecret, encoded, OAuthNamespace, secrets.LiteralSecretType)
+		secret, err := secrets.GenSecret(errorSecret, []byte(templates.Error), OAuthNamespace, secrets.LiteralSecretType)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -42,8 +38,7 @@ func translateTemplates(templates legacyconfigv1.OAuthTemplates) (*configv1.OAut
 	}
 
 	if templates.ProviderSelection != "" {
-		encoded := base64.StdEncoding.EncodeToString([]byte(templates.ProviderSelection))
-		secret, err := secrets.GenSecret(providerSelectionSecret, encoded, OAuthNamespace, secrets.LiteralSecretType)
+		secret, err := secrets.GenSecret(providerSelectionSecret, []byte(templates.ProviderSelection), OAuthNamespace, secrets.LiteralSecretType)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/transform/secrets/secrets.go
+++ b/pkg/transform/secrets/secrets.go
@@ -62,10 +62,14 @@ func GenTLSSecret(name string, namespace string, cert []byte, key []byte) (*core
 }
 
 // GenSecret generates a secret
-func GenSecret(name string, secretContent string, namespace string, secretType SecretType) (*corev1.Secret, error) {
+func GenSecret(name string, secretContent []byte, namespace string, secretType SecretType) (*corev1.Secret, error) {
 	nameErrors := validation.IsDNS1123Label(name)
 	if nameErrors != nil {
 		return nil, errors.New(secretNameError)
+	}
+
+	if secretContent == nil {
+		secretContent = []byte("")
 	}
 
 	data, err := buildData(secretType, secretContent)
@@ -89,25 +93,25 @@ func GenSecret(name string, secretContent string, namespace string, secretType S
 	return secret, nil
 }
 
-func buildData(secretType SecretType, secretContent string) (map[string][]byte, error) {
+func buildData(secretType SecretType, secretContent []byte) (map[string][]byte, error) {
 	var data map[string][]byte
 
 	switch secretType {
 	case KeystoneSecretType:
 		data = map[string][]byte{
-			"keystone": []byte(secretContent),
+			"keystone": secretContent,
 		}
 	case HtpasswdSecretType:
 		data = map[string][]byte{
-			"htpasswd": []byte(secretContent),
+			"htpasswd": secretContent,
 		}
 	case LiteralSecretType:
 		data = map[string][]byte{
-			"clientSecret": []byte(secretContent),
+			"clientSecret": secretContent,
 		}
 	case BasicAuthSecretType:
 		data = map[string][]byte{
-			"basicAuth": []byte(secretContent),
+			"basicAuth": secretContent,
 		}
 	default:
 		return nil, errors.New("Unknown secret type")

--- a/pkg/transform/secrets/secrets_test.go
+++ b/pkg/transform/secrets/secrets_test.go
@@ -116,7 +116,7 @@ func TestGenSecret(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resSecret, err := GenSecret(tc.inputSecretName, tc.inputSecretFile, "openshift-config", tc.inputSecretType)
+			resSecret, err := GenSecret(tc.inputSecretName, []byte(tc.inputSecretFile), "openshift-config", tc.inputSecretType)
 			if tc.expectederr {
 				err := errors.New("Not valid secret type " + "notvalidtype")
 				require.Error(t, err)

--- a/pkg/transform/testdata/expected-CR-secret-github-secret.yaml
+++ b/pkg/transform/testdata/expected-CR-secret-github-secret.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  clientSecret: Wm1GclpTMXpaV055WlhRPQ==
+  clientSecret: ZmFrZS1zZWNyZXQ=
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/pkg/transform/testdata/expected-CR-secret-gitlab-secret.yaml
+++ b/pkg/transform/testdata/expected-CR-secret-gitlab-secret.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  clientSecret: Wm1GclpTMXpaV055WlhRPQ==
+  clientSecret: ZmFrZS1zZWNyZXQ=
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/pkg/transform/testdata/expected-CR-secret-google.yaml
+++ b/pkg/transform/testdata/expected-CR-secret-google.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  clientSecret: Wm1GclpTMXpaV055WlhRPQ==
+  clientSecret: ZmFrZS1zZWNyZXQ=
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/pkg/transform/testdata/expected-CR-secret-openid.yaml
+++ b/pkg/transform/testdata/expected-CR-secret-openid.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  clientSecret: ZEdWemRITmxZM0psZEE9PQ==
+  clientSecret: dGVzdHNlY3JldA==
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/pkg/transform/testdata/expected-CR-secret-templates-error-secret.yaml
+++ b/pkg/transform/testdata/expected-CR-secret-templates-error-secret.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  clientSecret: ZEdWemRHVnljbTl5
+  clientSecret: dGVzdGVycm9y
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/pkg/transform/testdata/expected-CR-secret-templates-login-secret.yaml
+++ b/pkg/transform/testdata/expected-CR-secret-templates-login-secret.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  clientSecret: ZEdWemRHeHZaMmx1
+  clientSecret: dGVzdGxvZ2lu
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/pkg/transform/testdata/expected-CR-secret-templates-providerselect-secret.yaml
+++ b/pkg/transform/testdata/expected-CR-secret-templates-providerselect-secret.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  clientSecret: ZEdWemRITmxiR1ZqZEdsdmJnPT0=
+  clientSecret: dGVzdHNlbGVjdGlvbg==
 kind: Secret
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
(cherry picked from commit a89d3cdf3518e6fca2a2e68ef35466ed1356cae1)