### PR TITLE
Report about OpenID issuer field 

### DIFF
--- a/pkg/transform/oauth_transform.go
+++ b/pkg/transform/oauth_transform.go
@@ -121,6 +121,16 @@ func (e OAuthExtraction) buildReportOutput() {
 					Confidence: HighConfidence,
 					Comment:    fmt.Sprintf("Identity provider %s is supported in OCP4", p.Name),
 				})
+			if p.Kind == "OpenIDIdentityProvider" {
+				componentReport.Reports = append(componentReport.Reports,
+					reportoutput.Report{
+						Name:       "Issuer",
+						Kind:       fmt.Sprintf("IdentityProviders:%s", p.Kind),
+						Supported:  true,
+						Confidence: HighConfidence,
+						Comment:    "OCP4 requires an 'issuer' URL, please edit OAuth manifest file and configure this field",
+					})
+			}
 		default:
 			componentReport.Reports = append(componentReport.Reports,
 				reportoutput.Report{

--- a/pkg/transform/testdata/expected-report-oauth.json
+++ b/pkg/transform/testdata/expected-report-oauth.json
@@ -66,6 +66,13 @@
           "supported": true,
           "confidence": 2,
           "comment": "Identity provider my_openid_connect is supported in OCP4"
+        }, 
+        {
+          "name": "Issuer",
+          "kind": "IdentityProviders:OpenIDIdentityProvider",
+          "supported": true,
+          "confidence": 2,
+          "comment": "OCP4 requires an 'issuer' URL, please edit OAuth manifest file and configure this field"
         },
         {
           "name": "AccessTokenMaxAgeSeconds",


### PR DESCRIPTION
OCP4 OAuth OpenID provider has a new field dubbed "issuer" [1].
Meanwhile the field is mandatory and cannot be empty ("").
Using the "self-issued" value [2] allows creation. 

[1] https://docs.openshift.com/container-platform/4.1/authentication/identity_providers/configuring-oidc-identity-provider.html#identity-provider-oidc-CR_configuring-oidc-identity-provider
[2] https://openid.net/specs/openid-connect-core-1_0.html#SelfIssued

fixes https://github.com/fusor/cpma/issues/413
https://bugzilla.redhat.com/show_bug.cgi?id=1755865