### PR TITLE
Secrets: add common base and handle data name by param

### DIFF
--- a/pkg/transform/apicert/apicert.go
+++ b/pkg/transform/apicert/apicert.go
@@ -97,7 +97,7 @@ func Translate(servingInfo legacyconfigv1.ServingInfo) (*corev1.Secret, error) {
 		return nil, nil
 	}
 
-	tlsSecret, err := secrets.GenTLSSecret(secretName, namespace, crtContent, keyContent)
+	tlsSecret, err := secrets.TLS(secretName, namespace, crtContent, keyContent)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to generate TLS secret, see error")
 	}

--- a/pkg/transform/oauth/basicauth.go
+++ b/pkg/transform/oauth/basicauth.go
@@ -1,6 +1,8 @@
 package oauth
 
 import (
+	"path/filepath"
+
 	configv1 "github.com/openshift/api/config/v1"
 
 	"github.com/fusor/cpma/pkg/transform/configmaps"
@@ -30,7 +32,6 @@ func buildBasicAuthIP(serializer *json.Serializer, p IdentityProvider) (*Provide
 	idP.MappingMethod = configv1.MappingMethodType(p.MappingMethod)
 	idP.BasicAuth = &configv1.BasicAuthIdentityProvider{}
 	idP.BasicAuth.URL = basicAuth.URL
-
 	if basicAuth.CA != "" {
 		caConfigmap := configmaps.GenConfigMap("basicauth-configmap", OAuthNamespace, p.CAData)
 		idP.BasicAuth.CA = configv1.ConfigMapNameReference{Name: caConfigmap.ObjectMeta.Name}
@@ -41,7 +42,7 @@ func buildBasicAuthIP(serializer *json.Serializer, p IdentityProvider) (*Provide
 		certSecretName := "basicauth-client-cert-secret"
 		idP.BasicAuth.TLSClientCert.Name = certSecretName
 
-		certSecret, err := secrets.GenSecret(certSecretName, p.CrtData, OAuthNamespace, secrets.BasicAuthSecretType)
+		certSecret, err := secrets.Opaque(certSecretName, p.CrtData, OAuthNamespace, filepath.Base(basicAuth.CertFile))
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to generate cert secret for basic auth, see error")
 		}
@@ -50,7 +51,7 @@ func buildBasicAuthIP(serializer *json.Serializer, p IdentityProvider) (*Provide
 		keySecretName := "basicauth-client-key-secret"
 		idP.BasicAuth.TLSClientKey.Name = keySecretName
 
-		keySecret, err := secrets.GenSecret(keySecretName, p.KeyData, OAuthNamespace, secrets.BasicAuthSecretType)
+		keySecret, err := secrets.Opaque(keySecretName, p.KeyData, OAuthNamespace, filepath.Base(basicAuth.KeyFile))
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to generate key secret for basic auth, see error")
 		}

--- a/pkg/transform/oauth/github.go
+++ b/pkg/transform/oauth/github.go
@@ -51,7 +51,7 @@ func buildGitHubIP(serializer *json.Serializer, p IdentityProvider) (*ProviderRe
 		return nil, errors.Wrap(err, "Failed to fetch client secret for for github, see error")
 	}
 
-	secret, err := secrets.GenSecret(secretName, []byte(secretContent), OAuthNamespace, secrets.LiteralSecretType)
+	secret, err := secrets.Opaque(secretName, []byte(secretContent), OAuthNamespace, "clientSecret")
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to generate client secret for for github, see error")
 	}

--- a/pkg/transform/oauth/gitlab.go
+++ b/pkg/transform/oauth/gitlab.go
@@ -45,7 +45,7 @@ func buildGitLabIP(serializer *json.Serializer, p IdentityProvider) (*ProviderRe
 		return nil, errors.Wrap(err, "Failed to fetch client secret for gitlab, see error")
 	}
 
-	secret, err := secrets.GenSecret(secretName, []byte(secretContent), OAuthNamespace, secrets.LiteralSecretType)
+	secret, err := secrets.Opaque(secretName, []byte(secretContent), OAuthNamespace, "clientSecret")
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to generate secret for gitlab, see error")
 	}

--- a/pkg/transform/oauth/google.go
+++ b/pkg/transform/oauth/google.go
@@ -37,7 +37,7 @@ func buildGoogleIP(serializer *json.Serializer, p IdentityProvider) (*ProviderRe
 		return nil, errors.Wrap(err, "Failed to fetch client secret for google, see error")
 	}
 
-	secret, err := secrets.GenSecret(secretName, []byte(secretContent), OAuthNamespace, secrets.LiteralSecretType)
+	secret, err := secrets.Opaque(secretName, []byte(secretContent), OAuthNamespace, "clientSecret")
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to generate client secret for google, see error")
 	}

--- a/pkg/transform/oauth/htpasswd.go
+++ b/pkg/transform/oauth/htpasswd.go
@@ -30,7 +30,7 @@ func buildHTPasswdIP(serializer *json.Serializer, p IdentityProvider) (*Provider
 	idP.HTPasswd = &configv1.HTPasswdIdentityProvider{}
 	idP.HTPasswd.FileData.Name = secretName
 
-	secret, err := secrets.GenSecret(secretName, p.HTFileData, OAuthNamespace, secrets.HtpasswdSecretType)
+	secret, err := secrets.Opaque(secretName, p.HTFileData, OAuthNamespace, "htpasswd")
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to generate secret for htpasswd, see error")
 	}

--- a/pkg/transform/oauth/keystone.go
+++ b/pkg/transform/oauth/keystone.go
@@ -45,7 +45,7 @@ func buildKeystoneIP(serializer *json.Serializer, p IdentityProvider) (*Provider
 	if keystone.CertFile != "" {
 		certSecretName := "keystone-client-cert-secret"
 		idP.Keystone.TLSClientCert.Name = certSecretName
-		certSecret, err := secrets.GenSecret(certSecretName, p.CrtData, OAuthNamespace, secrets.KeystoneSecretType)
+		certSecret, err := secrets.Opaque(certSecretName, p.CrtData, OAuthNamespace, "keystone")
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to generate cert secret for keystone, see error")
 		}
@@ -53,7 +53,7 @@ func buildKeystoneIP(serializer *json.Serializer, p IdentityProvider) (*Provider
 
 		keySecretName := "keystone-client-key-secret"
 		idP.Keystone.TLSClientKey.Name = keySecretName
-		keySecret, err := secrets.GenSecret(keySecretName, p.KeyData, OAuthNamespace, secrets.KeystoneSecretType)
+		keySecret, err := secrets.Opaque(keySecretName, p.KeyData, OAuthNamespace, "keystone")
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to generate key secret for keystone, see error")
 		}

--- a/pkg/transform/oauth/openid.go
+++ b/pkg/transform/oauth/openid.go
@@ -39,7 +39,7 @@ func buildOpenIDIP(serializer *json.Serializer, p IdentityProvider) (*ProviderRe
 		return nil, errors.Wrap(err, "Failed to fetch client secret for openID, see error")
 	}
 
-	secret, err := secrets.GenSecret(secretName, []byte(secretContent), OAuthNamespace, secrets.LiteralSecretType)
+	secret, err := secrets.Opaque(secretName, []byte(secretContent), OAuthNamespace, "clientSecret")
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to generate secret for openID, see error")
 	}

--- a/pkg/transform/oauth/templates.go
+++ b/pkg/transform/oauth/templates.go
@@ -20,7 +20,7 @@ func translateTemplates(templates legacyconfigv1.OAuthTemplates) (*configv1.OAut
 	translatedTemplates := &configv1.OAuthTemplates{}
 
 	if templates.Login != "" {
-		secret, err := secrets.GenSecret(loginSecret, []byte(templates.Login), OAuthNamespace, secrets.LiteralSecretType)
+		secret, err := secrets.Opaque(loginSecret, []byte(templates.Login), OAuthNamespace, "clientSecret")
 		if err != nil {
 			return nil, nil, err
 		}
@@ -29,7 +29,7 @@ func translateTemplates(templates legacyconfigv1.OAuthTemplates) (*configv1.OAut
 	}
 
 	if templates.Error != "" {
-		secret, err := secrets.GenSecret(errorSecret, []byte(templates.Error), OAuthNamespace, secrets.LiteralSecretType)
+		secret, err := secrets.Opaque(errorSecret, []byte(templates.Error), OAuthNamespace, "clientSecret")
 		if err != nil {
 			return nil, nil, err
 		}
@@ -38,7 +38,7 @@ func translateTemplates(templates legacyconfigv1.OAuthTemplates) (*configv1.OAut
 	}
 
 	if templates.ProviderSelection != "" {
-		secret, err := secrets.GenSecret(providerSelectionSecret, []byte(templates.ProviderSelection), OAuthNamespace, secrets.LiteralSecretType)
+		secret, err := secrets.Opaque(providerSelectionSecret, []byte(templates.ProviderSelection), OAuthNamespace, "clientSecret")
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/transform/oauth_transform.go
+++ b/pkg/transform/oauth_transform.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fusor/cpma/pkg/io"
 	"github.com/fusor/cpma/pkg/transform/oauth"
 	"github.com/fusor/cpma/pkg/transform/reportoutput"
-	configv1 "github.com/openshift/api/legacyconfig/v1"
+	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -21,7 +21,7 @@ const OAuthComponentName = "OAuth"
 type OAuthExtraction struct {
 	IdentityProviders []oauth.IdentityProvider
 	TokenConfig       oauth.TokenConfig
-	Templates         configv1.OAuthTemplates
+	Templates         legacyconfigv1.OAuthTemplates
 }
 
 // OAuthTransform is an OAuth specific transform

--- a/pkg/transform/secrets/secrets.go
+++ b/pkg/transform/secrets/secrets.go
@@ -8,35 +8,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 )
 
-// SecretType is an enumerator for secret types
-type SecretType int
-
-const (
-	// KeystoneSecretType - keystone type for Secret
-	KeystoneSecretType = iota
-	// HtpasswdSecretType - htpasswd type for Secret
-	HtpasswdSecretType
-	// LiteralSecretType - literal type for Secret
-	LiteralSecretType
-	// BasicAuthSecretType - basicauth type for Secret
-	BasicAuthSecretType
-)
-
-var typeArray = []string{
-	"KeystoneSecretType",
-	"HtpasswdSecretType",
-	"LiteralSecretType",
-	"BasicAuthSecretType",
-}
-
 const (
 	apiVersion      = "v1"
 	secretNameError = `Secret name is no valid, make sure it consists of lower case alphanumeric characters, ‘-’ or ‘.’,` +
 		`and must start and end with an alphanumeric character (e.g. ‘example.com’, regex used for validation is ‘[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*’)`
 )
 
-// GenTLSSecret generates a TLS secret
-func GenTLSSecret(name string, namespace string, cert []byte, key []byte) (*corev1.Secret, error) {
+// new creates a secret core without Type and Data
+func new(name string, namespace string, secretType corev1.SecretType, data map[string][]byte) (*corev1.Secret, error) {
 	nameErrors := validation.IsDNS1123Label(name)
 	if nameErrors != nil {
 		return nil, errors.New(secretNameError)
@@ -51,71 +30,32 @@ func GenTLSSecret(name string, namespace string, cert []byte, key []byte) (*core
 			Name:      name,
 			Namespace: namespace,
 		},
-		Type: "kubernetes.io/tls",
-		Data: map[string][]byte{
-			"tls.cert": cert,
-			"tls.key":  key,
-		},
-	}
-
-	return secret, nil
-}
-
-// GenSecret generates a secret
-func GenSecret(name string, secretContent []byte, namespace string, secretType SecretType) (*corev1.Secret, error) {
-	nameErrors := validation.IsDNS1123Label(name)
-	if nameErrors != nil {
-		return nil, errors.New(secretNameError)
-	}
-
-	if secretContent == nil {
-		secretContent = []byte("")
-	}
-
-	data, err := buildData(secretType, secretContent)
-	if err != nil {
-		return nil, err
-	}
-
-	secret := &corev1.Secret{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: apiVersion,
-			Kind:       "Secret",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Type: "Opaque",
+		Type: secretType,
 		Data: data,
 	}
 
 	return secret, nil
 }
 
-func buildData(secretType SecretType, secretContent []byte) (map[string][]byte, error) {
-	var data map[string][]byte
-
-	switch secretType {
-	case KeystoneSecretType:
-		data = map[string][]byte{
-			"keystone": secretContent,
-		}
-	case HtpasswdSecretType:
-		data = map[string][]byte{
-			"htpasswd": secretContent,
-		}
-	case LiteralSecretType:
-		data = map[string][]byte{
-			"clientSecret": secretContent,
-		}
-	case BasicAuthSecretType:
-		data = map[string][]byte{
-			"basicAuth": secretContent,
-		}
-	default:
-		return nil, errors.New("Unknown secret type")
+// TLS generates a TLS secret
+func TLS(name string, namespace string, cert []byte, key []byte) (*corev1.Secret, error) {
+	data := map[string][]byte{
+		"tls.cert": cert,
+		"tls.key":  key,
 	}
 
-	return data, nil
+	return new(name, namespace, corev1.SecretTypeTLS, data)
+}
+
+// Opaque generates an Opaque secret
+func Opaque(name string, secretContent []byte, namespace string, dataName string) (*corev1.Secret, error) {
+	if secretContent == nil {
+		secretContent = []byte("")
+	}
+
+	data := map[string][]byte{
+		dataName: secretContent,
+	}
+
+	return new(name, namespace, corev1.SecretTypeOpaque, data)
 }

--- a/pkg/transform/secrets/secrets_test.go
+++ b/pkg/transform/secrets/secrets_test.go
@@ -17,7 +17,7 @@ func TestGenSecret(t *testing.T) {
 		name            string
 		inputSecretName string
 		inputSecretFile string
-		inputSecretType SecretType
+		inputSecretType string
 		expected        corev1.Secret
 		expectederr     bool
 	}{
@@ -25,7 +25,7 @@ func TestGenSecret(t *testing.T) {
 			name:            "generate htpasswd secret",
 			inputSecretName: "htpasswd-test",
 			inputSecretFile: "testfile1",
-			inputSecretType: HtpasswdSecretType,
+			inputSecretType: "htpasswd",
 			expected: corev1.Secret{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "v1",
@@ -46,7 +46,7 @@ func TestGenSecret(t *testing.T) {
 			name:            "generate keystone secret",
 			inputSecretName: "keystone-test",
 			inputSecretFile: "testfile2",
-			inputSecretType: KeystoneSecretType,
+			inputSecretType: "keystone",
 			expected: corev1.Secret{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "v1",
@@ -67,14 +67,14 @@ func TestGenSecret(t *testing.T) {
 			name:            "generate basic auth secret",
 			inputSecretName: "basicauth-test",
 			inputSecretFile: "testfile3",
-			inputSecretType: BasicAuthSecretType,
+			inputSecretType: "testname",
 			expected: corev1.Secret{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "v1",
 					Kind:       "Secret",
 				},
 				Data: map[string][]byte{
-					"basicAuth": []byte("testfile3"),
+					"testname": []byte("testfile3"),
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "basicauth-test",
@@ -88,7 +88,7 @@ func TestGenSecret(t *testing.T) {
 			name:            "generate litetal secret",
 			inputSecretName: "literal-secret",
 			inputSecretFile: "some-value",
-			inputSecretType: LiteralSecretType,
+			inputSecretType: "clientSecret",
 			expected: corev1.Secret{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "v1",
@@ -105,18 +105,11 @@ func TestGenSecret(t *testing.T) {
 			},
 			expectederr: false,
 		},
-		{
-			name:            "fail generating invalid secret",
-			inputSecretName: "notvalid-secret",
-			inputSecretFile: "some-value",
-			inputSecretType: 42, // Unknown secret type value
-			expectederr:     true,
-		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resSecret, err := GenSecret(tc.inputSecretName, []byte(tc.inputSecretFile), "openshift-config", tc.inputSecretType)
+			resSecret, err := Opaque(tc.inputSecretName, []byte(tc.inputSecretFile), "openshift-config", tc.inputSecretType)
 			if tc.expectederr {
 				err := errors.New("Not valid secret type " + "notvalidtype")
 				require.Error(t, err)

--- a/pkg/transform/testdata/expected-CR-secret-basicauth-client-cert-secret.yaml
+++ b/pkg/transform/testdata/expected-CR-secret-basicauth-client-cert-secret.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  basicAuth: ""
+  client.crt: ""
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/pkg/transform/testdata/expected-CR-secret-basicauth-client-key-secret.yaml
+++ b/pkg/transform/testdata/expected-CR-secret-basicauth-client-key-secret.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  basicAuth: ""
+  client.key: ""
 kind: Secret
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
Adds `new()` creating the secret using SecretType and Data as parameters.
The main driver is because `corev1.Secret.Data` field is a map[string][]byte which key is variable, for instance with `basicAuth` it's expected to be the name of the cert or key file.

Also renames: 
- `secrets.GenTLSSecret` to `secrets.TLS`
- `secrets.GenSecret` to `secrets.Opaque`

Fixes  https://bugzilla.redhat.com/show_bug.cgi?id=1760875