### PR TITLE
ConfigMaps use k8s definition; data uses ca.crt (#418)

### DIFF
--- a/pkg/transform/configmaps/configmaps.go
+++ b/pkg/transform/configmaps/configmaps.go
@@ -1,42 +1,25 @@
 package configmaps
 
-// ConfigMap represent configmap definition
-type ConfigMap struct {
-	APIVersion string   `json:"apiVersion"`
-	Kind       string   `json:"kind"`
-	Metadata   MetaData `json:"metadata"`
-	Data       Data     `json:"data"`
-}
-
-// MetaData configmap's metadata
-type MetaData struct {
-	Name      string `json:"name"`
-	Namespace string `json:"namespace"`
-}
-
-// Data contains CA
-type Data struct {
-	CAData string `json:"ca"`
-}
-
-const (
-	// APIVersion is the apiVersion string
-	APIVersion = "v1"
-	// Kind is config map resource type
-	Kind = "ConfigMap"
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// GenConfigMap generates a secret
-func GenConfigMap(name string, namespace string, CAData []byte) *ConfigMap {
-	return &ConfigMap{
-		APIVersion: APIVersion,
-		Data: Data{
-			CAData: string(CAData),
+// GenConfigMap generates a ConfigMap for certificate authority
+func GenConfigMap(name string, namespace string, CAData []byte) *corev1.ConfigMap {
+	configMap := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
 		},
-		Kind: Kind,
-		Metadata: MetaData{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
+		Data: map[string]string{
+			"ca.crt": string(CAData),
+		},
 	}
+
+	return configMap
 }

--- a/pkg/transform/configmaps/configmaps_test.go
+++ b/pkg/transform/configmaps/configmaps_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGenConfigMap(t *testing.T) {
@@ -13,22 +16,24 @@ func TestGenConfigMap(t *testing.T) {
 		configMapname string
 		CAData        []byte
 		namespace     string
-		expected      ConfigMap
+		expected      corev1.ConfigMap
 	}{
 		{
 			name:          "generate configmap",
 			configMapname: "testname",
 			CAData:        []byte("testdata"),
 			namespace:     "openshift-config",
-			expected: ConfigMap{
-				APIVersion: APIVersion,
-				Data: Data{
-					CAData: "testdata",
+			expected: corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
 				},
-				Kind: Kind,
-				Metadata: MetaData{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "testname",
 					Namespace: "openshift-config",
+				},
+				Data: map[string]string{
+					"ca.crt": "testdata",
 				},
 			},
 		},

--- a/pkg/transform/oauth/basicauth.go
+++ b/pkg/transform/oauth/basicauth.go
@@ -18,7 +18,7 @@ func buildBasicAuthIP(serializer *json.Serializer, p IdentityProvider) (*Provide
 		idP                = &configv1.IdentityProvider{}
 		basicAuth          legacyconfigv1.BasicAuthPasswordIdentityProvider
 		providerSecrets    []*corev1.Secret
-		providerConfigMaps []*configmaps.ConfigMap
+		providerConfigMaps []*corev1.ConfigMap
 	)
 
 	if _, _, err = serializer.Decode(p.Provider.Raw, nil, &basicAuth); err != nil {
@@ -33,7 +33,7 @@ func buildBasicAuthIP(serializer *json.Serializer, p IdentityProvider) (*Provide
 
 	if basicAuth.CA != "" {
 		caConfigmap := configmaps.GenConfigMap("basicauth-configmap", OAuthNamespace, p.CAData)
-		idP.BasicAuth.CA = configv1.ConfigMapNameReference{Name: caConfigmap.Metadata.Name}
+		idP.BasicAuth.CA = configv1.ConfigMapNameReference{Name: caConfigmap.ObjectMeta.Name}
 		providerConfigMaps = append(providerConfigMaps, caConfigmap)
 	}
 

--- a/pkg/transform/oauth/github.go
+++ b/pkg/transform/oauth/github.go
@@ -17,7 +17,7 @@ func buildGitHubIP(serializer *json.Serializer, p IdentityProvider) (*ProviderRe
 		err                error
 		idP                = &configv1.IdentityProvider{}
 		providerSecrets    []*corev1.Secret
-		providerConfigMaps []*configmaps.ConfigMap
+		providerConfigMaps []*corev1.ConfigMap
 		github             legacyconfigv1.GitHubIdentityProvider
 	)
 
@@ -40,7 +40,7 @@ func buildGitHubIP(serializer *json.Serializer, p IdentityProvider) (*ProviderRe
 
 	if github.CA != "" {
 		caConfigmap := configmaps.GenConfigMap("github-configmap", OAuthNamespace, p.CAData)
-		idP.GitHub.CA = configv1.ConfigMapNameReference{Name: caConfigmap.Metadata.Name}
+		idP.GitHub.CA = configv1.ConfigMapNameReference{Name: caConfigmap.ObjectMeta.Name}
 		providerConfigMaps = append(providerConfigMaps, caConfigmap)
 	}
 

--- a/pkg/transform/oauth/gitlab.go
+++ b/pkg/transform/oauth/gitlab.go
@@ -17,7 +17,7 @@ func buildGitLabIP(serializer *json.Serializer, p IdentityProvider) (*ProviderRe
 		err                error
 		idP                = &configv1.IdentityProvider{}
 		providerSecrets    []*corev1.Secret
-		providerConfigMaps []*configmaps.ConfigMap
+		providerConfigMaps []*corev1.ConfigMap
 		gitlab             legacyconfigv1.GitLabIdentityProvider
 	)
 
@@ -34,7 +34,7 @@ func buildGitLabIP(serializer *json.Serializer, p IdentityProvider) (*ProviderRe
 
 	if gitlab.CA != "" {
 		caConfigmap := configmaps.GenConfigMap("gitlab-configmap", OAuthNamespace, p.CAData)
-		idP.GitLab.CA = configv1.ConfigMapNameReference{Name: caConfigmap.Metadata.Name}
+		idP.GitLab.CA = configv1.ConfigMapNameReference{Name: caConfigmap.ObjectMeta.Name}
 		providerConfigMaps = append(providerConfigMaps, caConfigmap)
 	}
 

--- a/pkg/transform/oauth/keystone.go
+++ b/pkg/transform/oauth/keystone.go
@@ -16,7 +16,7 @@ func buildKeystoneIP(serializer *json.Serializer, p IdentityProvider) (*Provider
 	var (
 		idP                = &configv1.IdentityProvider{}
 		providerSecrets    []*corev1.Secret
-		providerConfigMaps []*configmaps.ConfigMap
+		providerConfigMaps []*corev1.ConfigMap
 		err                error
 		keystone           legacyconfigv1.KeystonePasswordIdentityProvider
 	)
@@ -34,7 +34,7 @@ func buildKeystoneIP(serializer *json.Serializer, p IdentityProvider) (*Provider
 
 	if keystone.CA != "" {
 		caConfigmap := configmaps.GenConfigMap("keystone-configmap", OAuthNamespace, p.CAData)
-		idP.Keystone.CA = configv1.ConfigMapNameReference{Name: caConfigmap.Metadata.Name}
+		idP.Keystone.CA = configv1.ConfigMapNameReference{Name: caConfigmap.ObjectMeta.Name}
 		providerConfigMaps = append(providerConfigMaps, caConfigmap)
 	}
 

--- a/pkg/transform/oauth/ldap.go
+++ b/pkg/transform/oauth/ldap.go
@@ -6,6 +6,8 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	"github.com/pkg/errors"
+
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
@@ -13,7 +15,7 @@ func buildLdapIP(serializer *json.Serializer, p IdentityProvider) (*ProviderReso
 	var (
 		err                error
 		idP                = &configv1.IdentityProvider{}
-		providerConfigMaps []*configmaps.ConfigMap
+		providerConfigMaps []*corev1.ConfigMap
 		ldap               legacyconfigv1.LDAPPasswordIdentityProvider
 	)
 
@@ -42,7 +44,7 @@ func buildLdapIP(serializer *json.Serializer, p IdentityProvider) (*ProviderReso
 
 	if ldap.CA != "" {
 		caConfigmap := configmaps.GenConfigMap("ldap-configmap", OAuthNamespace, p.CAData)
-		idP.LDAP.CA = configv1.ConfigMapNameReference{Name: caConfigmap.Metadata.Name}
+		idP.LDAP.CA = configv1.ConfigMapNameReference{Name: caConfigmap.ObjectMeta.Name}
 		providerConfigMaps = append(providerConfigMaps, caConfigmap)
 	}
 

--- a/pkg/transform/oauth/oauth.go
+++ b/pkg/transform/oauth/oauth.go
@@ -3,7 +3,6 @@ package oauth
 import (
 	"errors"
 
-	"github.com/fusor/cpma/pkg/transform/configmaps"
 	configv1 "github.com/openshift/api/config/v1"
 	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	oauthv1 "github.com/openshift/api/oauth/v1"
@@ -55,14 +54,14 @@ type IdentityProvider struct {
 type ResultResources struct {
 	OAuthCRD   *configv1.OAuth
 	Secrets    []*corev1.Secret
-	ConfigMaps []*configmaps.ConfigMap
+	ConfigMaps []*corev1.ConfigMap
 }
 
 // ProviderResources stores all resources related to one provider
 type ProviderResources struct {
 	IDP        *configv1.IdentityProvider
 	Secrets    []*corev1.Secret
-	ConfigMaps []*configmaps.ConfigMap
+	ConfigMaps []*corev1.ConfigMap
 }
 
 // TokenConfig store internal OAuth tokens duration
@@ -82,7 +81,7 @@ const (
 func Translate(identityProviders []IdentityProvider, tokenConfig TokenConfig, templates legacyconfigv1.OAuthTemplates) (*ResultResources, error) {
 	var err error
 	var secretsSlice []*corev1.Secret
-	var сonfigMapSlice []*configmaps.ConfigMap
+	var сonfigMapSlice []*corev1.ConfigMap
 	var providerResources *ProviderResources
 
 	// Translate configuration of diffent oAuth providers to CRD, secrets and config maps

--- a/pkg/transform/oauth/requestheader.go
+++ b/pkg/transform/oauth/requestheader.go
@@ -5,6 +5,8 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 )
 
@@ -12,7 +14,7 @@ func buildRequestHeaderIP(serializer *json.Serializer, p IdentityProvider) (*Pro
 	var (
 		err                error
 		idP                = &configv1.IdentityProvider{}
-		providerConfigMaps []*configmaps.ConfigMap
+		providerConfigMaps []*corev1.ConfigMap
 		requestHeader      legacyconfigv1.RequestHeaderIdentityProvider
 	)
 
@@ -29,7 +31,7 @@ func buildRequestHeaderIP(serializer *json.Serializer, p IdentityProvider) (*Pro
 
 	if requestHeader.ClientCA != "" {
 		caConfigmap := configmaps.GenConfigMap("requestheader-configmap", OAuthNamespace, p.CAData)
-		idP.RequestHeader.ClientCA = configv1.ConfigMapNameReference{Name: caConfigmap.Metadata.Name}
+		idP.RequestHeader.ClientCA = configv1.ConfigMapNameReference{Name: caConfigmap.ObjectMeta.Name}
 		providerConfigMaps = append(providerConfigMaps, caConfigmap)
 	}
 

--- a/pkg/transform/oauth_transform.go
+++ b/pkg/transform/oauth_transform.go
@@ -88,7 +88,7 @@ func (e OAuthExtraction) buildManifestOutput() (Output, error) {
 				return nil, err
 			}
 
-			filename := "100_CPMA-cluster-config-configmap-" + configMap.Metadata.Name + ".yaml"
+			filename := "100_CPMA-cluster-config-configmap-" + configMap.ObjectMeta.Name + ".yaml"
 			m := Manifest{Name: filename, CRD: configMapYAML}
 			manifests = append(manifests, m)
 		}

--- a/pkg/transform/testdata/expected-CR-configmap-basicauth.yaml
+++ b/pkg/transform/testdata/expected-CR-configmap-basicauth.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 data:
-  ca: ""
+  ca.crt: ""
 kind: ConfigMap
 metadata:
+  creationTimestamp: null
   name: basicauth-configmap
   namespace: openshift-config

--- a/pkg/transform/testdata/expected-CR-configmap-github.yaml
+++ b/pkg/transform/testdata/expected-CR-configmap-github.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 data:
-  ca: ""
+  ca.crt: ""
 kind: ConfigMap
 metadata:
+  creationTimestamp: null
   name: github-configmap
   namespace: openshift-config

--- a/pkg/transform/testdata/expected-CR-configmap-gitlab.yaml
+++ b/pkg/transform/testdata/expected-CR-configmap-gitlab.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 data:
-  ca: ""
+  ca.crt: ""
 kind: ConfigMap
 metadata:
+  creationTimestamp: null
   name: gitlab-configmap
   namespace: openshift-config

--- a/pkg/transform/testdata/expected-CR-configmap-keystone.yaml
+++ b/pkg/transform/testdata/expected-CR-configmap-keystone.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 data:
-  ca: ""
+  ca.crt: ""
 kind: ConfigMap
 metadata:
+  creationTimestamp: null
   name: keystone-configmap
   namespace: openshift-config

--- a/pkg/transform/testdata/expected-CR-configmap-ldap.yaml
+++ b/pkg/transform/testdata/expected-CR-configmap-ldap.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 data:
-  ca: ""
+  ca.crt: ""
 kind: ConfigMap
 metadata:
+  creationTimestamp: null
   name: ldap-configmap
   namespace: openshift-config

--- a/pkg/transform/testdata/expected-CR-configmap-requestheader.yaml
+++ b/pkg/transform/testdata/expected-CR-configmap-requestheader.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 data:
-  ca: ""
+  ca.crt: ""
 kind: ConfigMap
 metadata:
+  creationTimestamp: null
   name: requestheader-configmap
   namespace: openshift-config

--- a/pkg/transform/testdata/expected-CR-configmap.yaml
+++ b/pkg/transform/testdata/expected-CR-configmap.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 data:
-  ca: 'testval: 123'
+  ca.crt: 'testval: 123'
 kind: ConfigMap
 metadata:
+  creationTimestamp: null
   name: testname
   namespace: openshift-config

--- a/pkg/transform/transform.go
+++ b/pkg/transform/transform.go
@@ -1,7 +1,6 @@
 package transform
 
 import (
-	"github.com/fusor/cpma/pkg/transform/configmaps"
 	"github.com/ghodss/yaml"
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/sirupsen/logrus"
@@ -40,7 +39,7 @@ type Cluster struct {
 type Master struct {
 	OAuth      configv1.OAuth
 	Secrets    []*corev1.Secret
-	ConfigMaps []*configmaps.ConfigMap
+	ConfigMaps []*corev1.ConfigMap
 }
 
 // Manifest to be exported for use with OCP 4

--- a/pkg/transform/transform_test.go
+++ b/pkg/transform/transform_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/fusor/cpma/pkg/decode"
 	"github.com/fusor/cpma/pkg/env"
-	"github.com/fusor/cpma/pkg/transform/configmaps"
 	"github.com/fusor/cpma/pkg/transform/oauth"
 	legacyconfigv1 "github.com/openshift/api/legacyconfig/v1"
 	"github.com/stretchr/testify/assert"
@@ -105,15 +104,17 @@ func TestAllOtherCRGenYaml(t *testing.T) {
 	}{
 		{
 			name: "generate yaml from configmap",
-			inputCR: configmaps.ConfigMap{
-				APIVersion: configmaps.APIVersion,
-				Data: configmaps.Data{
-					CAData: "testval: 123",
+			inputCR: corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
 				},
-				Kind: configmaps.Kind,
-				Metadata: configmaps.MetaData{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "testname",
 					Namespace: "openshift-config",
+				},
+				Data: map[string]string{
+					"ca.crt": "testval: 123",
 				},
 			},
 			expectedYaml: expectedConfigMapYaml,


### PR DESCRIPTION
(cherry picked from commit fa9a7dd6aaf4c0fd052de82229018b0e7ed63eef)