### PR TITLE
BasicAuth provider secret: specific names for data fields

### DIFF
--- a/pkg/transform/oauth/basicauth.go
+++ b/pkg/transform/oauth/basicauth.go
@@ -1,8 +1,6 @@
 package oauth
 
 import (
-	"path/filepath"
-
 	configv1 "github.com/openshift/api/config/v1"
 
 	"github.com/fusor/cpma/pkg/transform/configmaps"
@@ -42,7 +40,7 @@ func buildBasicAuthIP(serializer *json.Serializer, p IdentityProvider) (*Provide
 		certSecretName := "basicauth-client-cert-secret"
 		idP.BasicAuth.TLSClientCert.Name = certSecretName
 
-		certSecret, err := secrets.Opaque(certSecretName, p.CrtData, OAuthNamespace, filepath.Base(basicAuth.CertFile))
+		certSecret, err := secrets.Opaque(certSecretName, p.CrtData, OAuthNamespace, "tls.crt")
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to generate cert secret for basic auth, see error")
 		}
@@ -51,7 +49,7 @@ func buildBasicAuthIP(serializer *json.Serializer, p IdentityProvider) (*Provide
 		keySecretName := "basicauth-client-key-secret"
 		idP.BasicAuth.TLSClientKey.Name = keySecretName
 
-		keySecret, err := secrets.Opaque(keySecretName, p.KeyData, OAuthNamespace, filepath.Base(basicAuth.KeyFile))
+		keySecret, err := secrets.Opaque(keySecretName, p.KeyData, OAuthNamespace, "tls.key")
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to generate key secret for basic auth, see error")
 		}

--- a/pkg/transform/testdata/expected-CR-secret-basicauth-client-cert-secret.yaml
+++ b/pkg/transform/testdata/expected-CR-secret-basicauth-client-cert-secret.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  client.crt: ""
+  tls.crt: ""
 kind: Secret
 metadata:
   creationTimestamp: null

--- a/pkg/transform/testdata/expected-CR-secret-basicauth-client-key-secret.yaml
+++ b/pkg/transform/testdata/expected-CR-secret-basicauth-client-key-secret.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  client.key: ""
+  tls.key: ""
 kind: Secret
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
Unfortunately OCP 4 doco isn't aligned with OCP behaviour.

https://bugzilla.redhat.com/show_bug.cgi?id=1760875