### PR TITLE
CRIO: Support for runtime table; removed unsupported field (#426)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -41,7 +41,7 @@ List of supported configuration to manifest translations:
   * API Certificate
   * When an API TLS Certificate defined in Master configuration file under ServingInfo section is not signed by openshif itself (therefore changed by user for a proper CA signed certificate) then it's ported to a TLS secret and saved under the '100_CPMA-cluster-config-APISecret.yaml' file. To apply the secret and update the API server, follow this [procedure](https://docs.openshift.com/container-platform/4.1/authentication/certificates/api-server.html#add-named-api-server_api-server-certificates).
   * CRI-O
-    * If defined in OCP3's cluster, the CRI-O configuration defined in 'crio.conf' is ported to a machineconfiguration.openshift.io resource and saved under '100_CPMA-crio-config.yaml'.
+    * If defined in OCP3's cluster, the CRI-O configuration defined in 'crio.conf' is ported to a machineconfiguration.openshift.io resource and saved under '100_CPMA-crio-config.yaml'. The Machine Configuration Operator supports only the runtime table for pids_limit, log_level and log_size_max. Other fields including globals and other tables fields are ignored.
   * Cluster Resources Quotas
     * Every quota defined at the cluster level is exported into equivalent OCP4 CR file. The file name is in the form: '100_CPMA-cluster-quota-resource-<ClusterQuota name>.yaml'
   * Resources Quotas

--- a/pkg/transform/crio_transform_test.go
+++ b/pkg/transform/crio_transform_test.go
@@ -17,12 +17,14 @@ import (
 var loadCrioExtraction = func() transform.CrioExtraction {
 	file := "testdata/crio.conf"
 	content, _ := ioutil.ReadFile(file)
-	var extraction transform.CrioExtraction
-	_, err := toml.Decode(string(content), &extraction)
+	var config transform.Crios
+	_, err := toml.Decode(string(content), &config)
 	if err != nil {
 		fmt.Printf("Error decoding file: %s\n", file)
 	}
 
+	var extraction transform.CrioExtraction
+	extraction.Runtime = config["crio"].Runtime
 	return extraction
 }()
 
@@ -37,7 +39,6 @@ func TestCrioExtractionTransform(t *testing.T) {
 	expectedCrd.Spec.ContainerRuntimeConfig.PidsLimit = 2048
 	expectedCrd.Spec.ContainerRuntimeConfig.LogLevel = "debug"
 	expectedCrd.Spec.ContainerRuntimeConfig.LogSizeMax = 100000
-	expectedCrd.Spec.ContainerRuntimeConfig.InfraImage = "image/infraImage:1"
 
 	crioCRYAML, err := yaml.Marshal(&expectedCrd)
 	require.NoError(t, err)
@@ -66,13 +67,6 @@ func TestCrioExtractionTransform(t *testing.T) {
 	expectedReport.Reports = append(expectedReport.Reports,
 		reportoutput.Report{
 			Name:       "logSizeMax",
-			Kind:       "Configuration",
-			Supported:  true,
-			Confidence: 2,
-		})
-	expectedReport.Reports = append(expectedReport.Reports,
-		reportoutput.Report{
-			Name:       "infrImage",
 			Kind:       "Configuration",
 			Supported:  true,
 			Confidence: 2,

--- a/pkg/transform/testdata/crio.conf
+++ b/pkg/transform/testdata/crio.conf
@@ -1,5 +1,7 @@
 [crio]
-pidsLimit = 2048
-logLevel = "debug"
-logSizeMax = 100000
-infraImage = "image/infraImage:1"
+version_file = "1.0"
+
+[crio.runtime]
+pids_limit = 2048
+log_level = "debug"
+log_size_max = 100000


### PR DESCRIPTION
(cherry picked from commit 295c63b1d5c0d68a01bbc263dee1013a2e687671)