### PR TITLE
Api init refactor

### DIFF
--- a/pkg/api/initclient.go
+++ b/pkg/api/initclient.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"runtime"
-	"sync"
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
@@ -29,17 +28,6 @@ var (
 
 	kubeConfigGetter = func() (*clientcmdapi.Config, error) {
 		return KubeConfig, nil
-	}
-
-	// singleton instances
-	instances struct {
-		Openshift *OpenshiftClient
-		K8S       *kubernetes.Clientset
-	}
-
-	once struct {
-		Openshift sync.Once
-		K8S       sync.Once
 	}
 )
 
@@ -92,9 +80,10 @@ func CreateK8sClient(contextCluster string) error {
 		return err
 	}
 
-	K8sClient = InitK8SOrDie(config)
-	logrus.Debugf("Kubernetes API client initialized for %s", contextCluster)
-
+	if K8sClient == nil {
+		K8sClient = NewK8SOrDie(config)
+		logrus.Debugf("Kubernetes API client initialized for %s", contextCluster)
+	}
 	return nil
 }
 
@@ -105,8 +94,10 @@ func CreateO7tClient(contextCluster string) error {
 		return err
 	}
 
-	O7tClient = InitO7tOrDie(config)
-	logrus.Debugf("Openshift API client initialized for %s", contextCluster)
+	if O7tClient == nil {
+		O7tClient = NewO7tOrDie(config)
+		logrus.Debugf("Openshift API client initialized for %s", contextCluster)
+	}
 
 	return nil
 }

--- a/pkg/api/k8s.go
+++ b/pkg/api/k8s.go
@@ -7,9 +7,5 @@ import (
 
 // NewK8SOrDie init k8s client or panic
 func NewK8SOrDie(config *rest.Config) *kubernetes.Clientset {
-	k8sClient, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		panic("Error in creating K8S API client")
-	}
-	return k8sClient
+	return kubernetes.NewForConfigOrDie(config)
 }

--- a/pkg/api/k8s.go
+++ b/pkg/api/k8s.go
@@ -5,14 +5,11 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-// InitK8SOrDie init k8s client or panic
-func InitK8SOrDie(config *rest.Config) *kubernetes.Clientset {
-	once.K8S.Do(func() {
-		k8sClient, err := kubernetes.NewForConfig(config)
-		if err != nil {
-			panic("Error in creating K8S API client")
-		}
-		instances.K8S = k8sClient
-	})
-	return instances.K8S
+// NewK8SOrDie init k8s client or panic
+func NewK8SOrDie(config *rest.Config) *kubernetes.Clientset {
+	k8sClient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		panic("Error in creating K8S API client")
+	}
+	return k8sClient
 }

--- a/pkg/api/openshift.go
+++ b/pkg/api/openshift.go
@@ -19,17 +19,14 @@ type OpenshiftClient struct {
 	userClient     user1.UserV1Interface
 }
 
-// InitO7tOrDie - Create a new openshift client if needed, returns reference
-func InitO7tOrDie(config *rest.Config) *OpenshiftClient {
-	once.Openshift.Do(func() {
-		client, err := newOpenshift(config)
-		instances.Openshift = client
-		if err != nil {
-			panic("OpenShift client failed to init")
-		}
-	})
+// NewO7tOrDie - Create a new openshift client if needed, returns reference
+func NewO7tOrDie(config *rest.Config) *OpenshiftClient {
+	client, err := newOpenshift(config)
+	if err != nil {
+		panic("OpenShift client failed to init")
+	}
 
-	return instances.Openshift
+	return client
 }
 
 func newOpenshift(config *rest.Config) (*OpenshiftClient, error) {

--- a/pkg/api/openshift.go
+++ b/pkg/api/openshift.go
@@ -21,45 +21,11 @@ type OpenshiftClient struct {
 
 // NewO7tOrDie - Create a new openshift client if needed, returns reference
 func NewO7tOrDie(config *rest.Config) *OpenshiftClient {
-	client, err := newOpenshift(config)
-	if err != nil {
-		panic("OpenShift client failed to init")
-	}
-
-	return client
-}
-
-func newOpenshift(config *rest.Config) (*OpenshiftClient, error) {
-	authClient, err := authv1.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-
-	quotaClient, err := quotav1.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-
-	routeClient, err := routev1.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-
-	securityClient, err := security1.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-
-	userClient, err := user1.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-
 	return &OpenshiftClient{
-		authClient:     authClient,
-		quotaClient:    quotaClient,
-		routeClient:    routeClient,
-		securityClient: securityClient,
-		userClient:     userClient,
-	}, nil
+		authClient:     authv1.NewForConfigOrDie(config),
+		quotaClient:    quotav1.NewForConfigOrDie(config),
+		routeClient:    routev1.NewForConfigOrDie(config),
+		securityClient: security1.NewForConfigOrDie(config),
+		userClient:     user1.NewForConfigOrDie(config),
+	}
 }


### PR DESCRIPTION
Using Once is overkill as we actually use variables to reference our API clients.
Also let's use client-go library to handle init or die approach.
This is to also help clearing path for dual connections to src/dst clusters at same time.