### PR TITLE
Discovery included

### DIFF
--- a/pkg/api/initclient.go
+++ b/pkg/api/initclient.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -26,8 +25,6 @@ var (
 	K8sClient *kubernetes.Clientset
 	// O7tClient api client used for connecting to Openshift api
 	O7tClient *OpenshiftClient
-	// Discovery client
-	Discovery *discovery.DiscoveryClient
 
 	kubeConfigGetter = func() (*clientcmdapi.Config, error) {
 		return KubeConfig, nil
@@ -74,21 +71,6 @@ func getKubeConfigPath() (string, error) {
 	}
 
 	return kubeConfigPath, nil
-}
-
-// CreateDiscoveryClient create api client using cluster from kubeconfig context
-func CreateDiscoveryClient(contextCluster string) error {
-	config, err := buildConfig(contextCluster)
-	if err != nil {
-		return err
-	}
-
-	if Discovery == nil {
-		Discovery = NewDiscoveryOrDie(config)
-		logrus.Debugf("Discovery API client initialized for %s", contextCluster)
-	}
-
-	return nil
 }
 
 // CreateK8sClient create api client using cluster from kubeconfig context

--- a/pkg/api/k8s.go
+++ b/pkg/api/k8s.go
@@ -1,15 +1,9 @@
 package api
 
 import (
-	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
-
-// NewDiscoveryOrDie init k8s client or panic
-func NewDiscoveryOrDie(config *rest.Config) *discovery.DiscoveryClient {
-	return discovery.NewDiscoveryClientForConfigOrDie(config)
-}
 
 // NewK8SOrDie init k8s client or panic
 func NewK8SOrDie(config *rest.Config) *kubernetes.Clientset {

--- a/pkg/api/requests.go
+++ b/pkg/api/requests.go
@@ -51,7 +51,7 @@ var listOptions metav1.ListOptions
 
 // ListGroupVersions list all GV
 func ListGroupVersions(ch chan<- *metav1.APIGroupList) {
-	groupVersions, err := Discovery.ServerGroups()
+	groupVersions, err := K8sClient.ServerGroups()
 	if err != nil {
 		logrus.Fatal(err)
 	}

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -363,9 +363,6 @@ func createAPIClients() error {
 	if api.O7tClient != nil && api.K8sClient != nil {
 		return nil
 	}
-	if err := api.CreateDiscoveryClient(viperConfig.GetString("ClusterName")); err != nil {
-		return errors.Wrap(err, "discovery api client failed to create")
-	}
 
 	if err := api.CreateK8sClient(viperConfig.GetString("ClusterName")); err != nil {
 		return errors.Wrap(err, "k8s api client failed to create")


### PR DESCRIPTION
There is no need to create a dedicated discovery client as the default k8s client structure contains discovery.