### PR TITLE
More generic API requests using client as param

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,6 +50,14 @@ func init() {
 	rootCmd.PersistentFlags().BoolP("debug", "d", false, "show debug ouput")
 	env.Config().BindPFlag("Debug", rootCmd.PersistentFlags().Lookup("debug"))
 
+	// Target cluster
+	rootCmd.PersistentFlags().Bool("target-cluster", false, "target cluster")
+	env.Config().BindPFlag("TargetCluster", rootCmd.PersistentFlags().Lookup("target-cluster"))
+
+	// Target cluster name for Kubeconfig context
+	rootCmd.PersistentFlags().StringP("target-cluster-name", "t", "", "target cluster name")
+	env.Config().BindPFlag("TargetClusterName", rootCmd.PersistentFlags().Lookup("target-cluster-name"))
+
 	// Get etcd config file location
 	rootCmd.PersistentFlags().String("etcd-config", "", "path to etcd config file")
 	env.Config().BindPFlag("ETCDConfigFile", rootCmd.PersistentFlags().Lookup("etcd-config"))

--- a/pkg/api/initclient.go
+++ b/pkg/api/initclient.go
@@ -21,9 +21,11 @@ var (
 	KubeConfig *clientcmdapi.Config
 	// ClusterNames contains names of contexts and cluster
 	ClusterNames = make(map[string]string)
-	// K8sClient api client used for connecting to k8s api
+	// K8sClient k8s api client for source cluster
 	K8sClient *kubernetes.Clientset
-	// O7tClient api client used for connecting to Openshift api
+	// K8sDstClient k8s api client for target cluster
+	K8sDstClient *kubernetes.Clientset
+	// O7tClient openshift api client for source cluster
 	O7tClient *OpenshiftClient
 
 	kubeConfigGetter = func() (*clientcmdapi.Config, error) {
@@ -71,6 +73,21 @@ func getKubeConfigPath() (string, error) {
 	}
 
 	return kubeConfigPath, nil
+}
+
+// CreateK8sDstClient create api client using cluster from kubeconfig context
+func CreateK8sDstClient(contextCluster string) error {
+	if K8sDstClient == nil {
+		config, err := buildConfig(contextCluster)
+		if err != nil {
+			return err
+		}
+
+		K8sDstClient = NewK8SOrDie(config)
+		logrus.Debugf("Kubernetes API client initialized for %s", contextCluster)
+	}
+
+	return nil
 }
 
 // CreateK8sClient create api client using cluster from kubeconfig context

--- a/pkg/api/initclient.go
+++ b/pkg/api/initclient.go
@@ -75,12 +75,12 @@ func getKubeConfigPath() (string, error) {
 
 // CreateK8sClient create api client using cluster from kubeconfig context
 func CreateK8sClient(contextCluster string) error {
-	config, err := buildConfig(contextCluster)
-	if err != nil {
-		return err
-	}
-
 	if K8sClient == nil {
+		config, err := buildConfig(contextCluster)
+		if err != nil {
+			return err
+		}
+
 		K8sClient = NewK8SOrDie(config)
 		logrus.Debugf("Kubernetes API client initialized for %s", contextCluster)
 	}
@@ -90,12 +90,12 @@ func CreateK8sClient(contextCluster string) error {
 
 // CreateO7tClient create api client using cluster from kubeconfig context
 func CreateO7tClient(contextCluster string) error {
-	config, err := buildConfig(contextCluster)
-	if err != nil {
-		return err
-	}
-
 	if O7tClient == nil {
+		config, err := buildConfig(contextCluster)
+		if err != nil {
+			return err
+		}
+
 		O7tClient = NewO7tOrDie(config)
 		logrus.Debugf("Openshift API client initialized for %s", contextCluster)
 	}

--- a/pkg/api/requests.go
+++ b/pkg/api/requests.go
@@ -13,6 +13,7 @@ import (
 	extv1b1 "k8s.io/api/extensions/v1beta1"
 	k8sapistorage "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 // Resources represent api resources used in report
@@ -50,8 +51,8 @@ type NamespaceResources struct {
 var listOptions metav1.ListOptions
 
 // ListGroupVersions list all GV
-func ListGroupVersions(ch chan<- *metav1.APIGroupList) {
-	groupVersions, err := K8sClient.ServerGroups()
+func ListGroupVersions(client *kubernetes.Clientset, ch chan<- *metav1.APIGroupList) {
+	groupVersions, err := client.ServerGroups()
 	if err != nil {
 		logrus.Fatal(err)
 	}
@@ -59,8 +60,8 @@ func ListGroupVersions(ch chan<- *metav1.APIGroupList) {
 }
 
 // ListNamespaces list all namespaces, wrapper around client-go
-func ListNamespaces(ch chan<- *k8sapicore.NamespaceList) {
-	namespaces, err := K8sClient.CoreV1().Namespaces().List(listOptions)
+func ListNamespaces(client *kubernetes.Clientset, ch chan<- *k8sapicore.NamespaceList) {
+	namespaces, err := client.CoreV1().Namespaces().List(listOptions)
 	if err != nil {
 		logrus.Fatal(err)
 	}
@@ -68,8 +69,8 @@ func ListNamespaces(ch chan<- *k8sapicore.NamespaceList) {
 }
 
 // ListPods list all pods in namespace, wrapper around client-go
-func ListPods(namespace string, ch chan<- *k8sapicore.PodList) {
-	pods, err := K8sClient.CoreV1().Pods(namespace).List(listOptions)
+func ListPods(client *kubernetes.Clientset, namespace string, ch chan<- *k8sapicore.PodList) {
+	pods, err := client.CoreV1().Pods(namespace).List(listOptions)
 	if err != nil {
 		logrus.Fatal(err)
 	}
@@ -77,8 +78,8 @@ func ListPods(namespace string, ch chan<- *k8sapicore.PodList) {
 }
 
 // ListPVs list all PVs, wrapper around client-go
-func ListPVs(ch chan<- *k8sapicore.PersistentVolumeList) {
-	pvs, err := K8sClient.CoreV1().PersistentVolumes().List(listOptions)
+func ListPVs(client *kubernetes.Clientset, ch chan<- *k8sapicore.PersistentVolumeList) {
+	pvs, err := client.CoreV1().PersistentVolumes().List(listOptions)
 	if err != nil {
 		logrus.Fatal(err)
 	}
@@ -86,8 +87,8 @@ func ListPVs(ch chan<- *k8sapicore.PersistentVolumeList) {
 }
 
 // ListNodes list all nodes, wrapper around client-go
-func ListNodes(ch chan<- *k8sapicore.NodeList) {
-	nodes, err := K8sClient.CoreV1().Nodes().List(listOptions)
+func ListNodes(client *kubernetes.Clientset, ch chan<- *k8sapicore.NodeList) {
+	nodes, err := client.CoreV1().Nodes().List(listOptions)
 	if err != nil {
 		logrus.Fatal(err)
 	}
@@ -95,8 +96,8 @@ func ListNodes(ch chan<- *k8sapicore.NodeList) {
 }
 
 // ListQuotas list all cluster quotas classes, wrapper around client-go
-func ListQuotas(ch chan<- *o7tapiquota.ClusterResourceQuotaList) {
-	quotas, err := O7tClient.quotaClient.ClusterResourceQuotas().List(listOptions)
+func ListQuotas(client *OpenshiftClient, ch chan<- *o7tapiquota.ClusterResourceQuotaList) {
+	quotas, err := client.quotaClient.ClusterResourceQuotas().List(listOptions)
 	if err != nil {
 		logrus.Fatal(err)
 	}
@@ -104,8 +105,8 @@ func ListQuotas(ch chan<- *o7tapiquota.ClusterResourceQuotaList) {
 }
 
 // ListResourceQuotas list all quotas classes, wrapper around client-go
-func ListResourceQuotas(namespace string, ch chan<- *k8sapicore.ResourceQuotaList) {
-	quotas, err := K8sClient.CoreV1().ResourceQuotas(namespace).List(listOptions)
+func ListResourceQuotas(client *kubernetes.Clientset, namespace string, ch chan<- *k8sapicore.ResourceQuotaList) {
+	quotas, err := client.CoreV1().ResourceQuotas(namespace).List(listOptions)
 	if err != nil {
 		logrus.Fatal(err)
 	}
@@ -113,8 +114,8 @@ func ListResourceQuotas(namespace string, ch chan<- *k8sapicore.ResourceQuotaLis
 }
 
 // ListRoutes list all routes classes, wrapper around client-go
-func ListRoutes(namespace string, ch chan<- *o7tapiroute.RouteList) {
-	routes, err := O7tClient.routeClient.Routes(namespace).List(listOptions)
+func ListRoutes(client *OpenshiftClient, namespace string, ch chan<- *o7tapiroute.RouteList) {
+	routes, err := client.routeClient.Routes(namespace).List(listOptions)
 	if err != nil {
 		logrus.Fatal(err)
 	}
@@ -122,8 +123,8 @@ func ListRoutes(namespace string, ch chan<- *o7tapiroute.RouteList) {
 }
 
 // ListStorageClasses list all storage classes, wrapper around client-go
-func ListStorageClasses(ch chan<- *k8sapistorage.StorageClassList) {
-	sc, err := K8sClient.StorageV1().StorageClasses().List(listOptions)
+func ListStorageClasses(client *kubernetes.Clientset, ch chan<- *k8sapistorage.StorageClassList) {
+	sc, err := client.StorageV1().StorageClasses().List(listOptions)
 	if err != nil {
 		logrus.Fatal(err)
 	}
@@ -131,8 +132,8 @@ func ListStorageClasses(ch chan<- *k8sapistorage.StorageClassList) {
 }
 
 // ListDeployments will list all deployments seeding in the selected namespace
-func ListDeployments(namespace string, ch chan<- *v1beta1.DeploymentList) {
-	deployments, err := K8sClient.AppsV1beta1().Deployments(namespace).List(listOptions)
+func ListDeployments(client *kubernetes.Clientset, namespace string, ch chan<- *v1beta1.DeploymentList) {
+	deployments, err := client.AppsV1beta1().Deployments(namespace).List(listOptions)
 	if err != nil {
 		logrus.Fatal(err)
 	}
@@ -140,8 +141,8 @@ func ListDeployments(namespace string, ch chan<- *v1beta1.DeploymentList) {
 }
 
 // ListDaemonSets will collect all DS from specific namespace
-func ListDaemonSets(namespace string, ch chan<- *extv1b1.DaemonSetList) {
-	daemonSets, err := K8sClient.ExtensionsV1beta1().DaemonSets(namespace).List(listOptions)
+func ListDaemonSets(client *kubernetes.Clientset, namespace string, ch chan<- *extv1b1.DaemonSetList) {
+	daemonSets, err := client.ExtensionsV1beta1().DaemonSets(namespace).List(listOptions)
 	if err != nil {
 		logrus.Fatal(err)
 	}
@@ -149,8 +150,8 @@ func ListDaemonSets(namespace string, ch chan<- *extv1b1.DaemonSetList) {
 }
 
 // ListUsers list all users, wrapper around client-go
-func ListUsers(ch chan<- *o7tapiuser.UserList) {
-	users, err := O7tClient.userClient.Users().List(listOptions)
+func ListUsers(client *OpenshiftClient, ch chan<- *o7tapiuser.UserList) {
+	users, err := client.userClient.Users().List(listOptions)
 	if err != nil {
 		logrus.Fatal(err)
 	}
@@ -158,8 +159,8 @@ func ListUsers(ch chan<- *o7tapiuser.UserList) {
 }
 
 // ListGroups list all users, wrapper around client-go
-func ListGroups(ch chan<- *o7tapiuser.GroupList) {
-	groups, err := O7tClient.userClient.Groups().List(listOptions)
+func ListGroups(client *OpenshiftClient, ch chan<- *o7tapiuser.GroupList) {
+	groups, err := client.userClient.Groups().List(listOptions)
 	if err != nil {
 		logrus.Fatal(err)
 	}
@@ -167,8 +168,8 @@ func ListGroups(ch chan<- *o7tapiuser.GroupList) {
 }
 
 // ListRoles list all storage classes, wrapper around client-go
-func ListRoles(namespace string, ch chan<- *o7tapiauth.RoleList) {
-	roles, err := O7tClient.authClient.Roles(namespace).List(listOptions)
+func ListRoles(client *OpenshiftClient, namespace string, ch chan<- *o7tapiauth.RoleList) {
+	roles, err := client.authClient.Roles(namespace).List(listOptions)
 	if err != nil {
 		logrus.Fatal(err)
 	}
@@ -176,8 +177,8 @@ func ListRoles(namespace string, ch chan<- *o7tapiauth.RoleList) {
 }
 
 // ListClusterRoles list all storage classes, wrapper around client-go
-func ListClusterRoles(ch chan<- *o7tapiauth.ClusterRoleList) {
-	clusterRoles, err := O7tClient.authClient.ClusterRoles().List(listOptions)
+func ListClusterRoles(client *OpenshiftClient, ch chan<- *o7tapiauth.ClusterRoleList) {
+	clusterRoles, err := client.authClient.ClusterRoles().List(listOptions)
 	if err != nil {
 		logrus.Fatal(err)
 	}
@@ -185,8 +186,8 @@ func ListClusterRoles(ch chan<- *o7tapiauth.ClusterRoleList) {
 }
 
 // ListClusterRolesBindings list all storage classes, wrapper around client-go
-func ListClusterRolesBindings(ch chan<- *o7tapiauth.ClusterRoleBindingList) {
-	clusterRolesBindings, err := O7tClient.authClient.ClusterRoleBindings().List(listOptions)
+func ListClusterRolesBindings(client *OpenshiftClient, ch chan<- *o7tapiauth.ClusterRoleBindingList) {
+	clusterRolesBindings, err := client.authClient.ClusterRoleBindings().List(listOptions)
 	if err != nil {
 		logrus.Fatal(err)
 	}
@@ -194,8 +195,8 @@ func ListClusterRolesBindings(ch chan<- *o7tapiauth.ClusterRoleBindingList) {
 }
 
 // ListSCC list all security context constraints, wrapper around client-go
-func ListSCC(ch chan<- *o7tapisecurity.SecurityContextConstraintsList) {
-	scc, err := O7tClient.securityClient.SecurityContextConstraints().List(listOptions)
+func ListSCC(client *OpenshiftClient, ch chan<- *o7tapisecurity.SecurityContextConstraintsList) {
+	scc, err := client.securityClient.SecurityContextConstraints().List(listOptions)
 	if err != nil {
 		logrus.Fatal(err)
 	}
@@ -203,8 +204,8 @@ func ListSCC(ch chan<- *o7tapisecurity.SecurityContextConstraintsList) {
 }
 
 // ListPVCs list all PVs, wrapper around client-go
-func ListPVCs(namespace string, ch chan<- *k8sapicore.PersistentVolumeClaimList) {
-	pvcs, err := K8sClient.CoreV1().PersistentVolumeClaims(namespace).List(listOptions)
+func ListPVCs(client *kubernetes.Clientset, namespace string, ch chan<- *k8sapicore.PersistentVolumeClaimList) {
+	pvcs, err := client.CoreV1().PersistentVolumeClaims(namespace).List(listOptions)
 	if err != nil {
 		logrus.Fatal(err)
 	}

--- a/pkg/env/clusterdiscovery/clusterdiscovery.go
+++ b/pkg/env/clusterdiscovery/clusterdiscovery.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 
 	k8sapicore "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
@@ -22,7 +23,7 @@ func DiscoverCluster() (string, string, error) {
 		return "", "", errors.Wrap(err, "k8s api client failed to create")
 	}
 
-	clusterNodes, err := queryNodes(api.K8sClient.CoreV1())
+	clusterNodes, err := queryNodes(api.K8sClient, api.K8sClient.CoreV1())
 	if err != nil {
 		return "", "", errors.Wrap(err, "cluster node query failed")
 	}
@@ -58,9 +59,9 @@ func SurveyClusters() string {
 	return selectedCluster
 }
 
-func queryNodes(apiClient corev1.CoreV1Interface) ([]string, error) {
+func queryNodes(client *kubernetes.Clientset, apiClient corev1.CoreV1Interface) ([]string, error) {
 	chanNodes := make(chan *k8sapicore.NodeList)
-	go api.ListNodes(chanNodes)
+	go api.ListNodes(client, chanNodes)
 	nodeList := <-chanNodes
 
 	nodes := make([]string, 0, len(nodeList.Items))

--- a/pkg/env/clusterdiscovery/clusterdiscovery.go
+++ b/pkg/env/clusterdiscovery/clusterdiscovery.go
@@ -7,7 +7,6 @@ import (
 
 	k8sapicore "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
 // DiscoverCluster Get kubeconfig using $KUBECONFIG, if not try ~/.kube/config
@@ -23,7 +22,7 @@ func DiscoverCluster() (string, string, error) {
 		return "", "", errors.Wrap(err, "k8s api client failed to create")
 	}
 
-	clusterNodes, err := queryNodes(api.K8sClient, api.K8sClient.CoreV1())
+	clusterNodes, err := queryNodes(api.K8sClient)
 	if err != nil {
 		return "", "", errors.Wrap(err, "cluster node query failed")
 	}
@@ -59,7 +58,7 @@ func SurveyClusters() string {
 	return selectedCluster
 }
 
-func queryNodes(client *kubernetes.Clientset, apiClient corev1.CoreV1Interface) ([]string, error) {
+func queryNodes(client *kubernetes.Clientset) ([]string, error) {
 	chanNodes := make(chan *k8sapicore.NodeList)
 	go api.ListNodes(client, chanNodes)
 	nodeList := <-chanNodes

--- a/pkg/env/clusterdiscovery/clusterdiscovery.go
+++ b/pkg/env/clusterdiscovery/clusterdiscovery.go
@@ -9,15 +9,17 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+// DiscoverDstCluster Get kubeconfig using $KUBECONFIG, if not try ~/.kube/config
+// parse kubeconfig and select targeted cluster from available contexts
+func DiscoverDstCluster() (string, error) {
+	return SurveyClusters(), nil
+}
+
 // DiscoverCluster Get kubeconfig using $KUBECONFIG, if not try ~/.kube/config
-// parse kubeconfig and select cluster from available contexts
+// parse kubeconfig and select source cluster from available contexts
 // query k8s api for nodes, get node urls from api response and survey master node
 func DiscoverCluster() (string, string, error) {
 	selectedCluster := SurveyClusters()
-
-	// set current context to selected cluster for connecting to cluster using client-go
-	api.KubeConfig.CurrentContext = api.ClusterNames[selectedCluster]
-
 	if err := api.CreateK8sClient(selectedCluster); err != nil {
 		return "", "", errors.Wrap(err, "k8s api client failed to create")
 	}
@@ -39,6 +41,7 @@ func SurveyClusters() string {
 	// It's better to have current context's cluster first, because
 	// it will be easier to select it using survey
 	currentContext := api.KubeConfig.CurrentContext
+
 	currentContextCluster := api.KubeConfig.Contexts[currentContext].Cluster
 	clusters = append(clusters, currentContextCluster)
 

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -125,10 +125,6 @@ func surveyMissingValues() error {
 		viperConfig.Set("FetchFromRemote", true)
 	}
 
-	if err := createAPIClients(); err != nil {
-		return err
-	}
-
 	if viperConfig.GetString("WorkDir") == "" {
 		workDir := "."
 		prompt := &survey.Input{
@@ -140,6 +136,14 @@ func surveyMissingValues() error {
 		}
 
 		viperConfig.Set("WorkDir", workDir)
+	}
+
+	if err := api.CreateK8sClient(viperConfig.GetString("ClusterName")); err != nil {
+		return errors.Wrap(err, "k8s api client failed to create")
+	}
+
+	if err := api.CreateO7tClient(viperConfig.GetString("ClusterName")); err != nil {
+		return errors.Wrap(err, "OpenShift api client failed to create")
 	}
 
 	return nil
@@ -354,22 +358,6 @@ func surveyConfigPaths() error {
 			return err
 		}
 		viperConfig.Set("RegistriesConfigFile", config)
-	}
-
-	return nil
-}
-
-func createAPIClients() error {
-	if api.O7tClient != nil && api.K8sClient != nil {
-		return nil
-	}
-
-	if err := api.CreateK8sClient(viperConfig.GetString("ClusterName")); err != nil {
-		return errors.Wrap(err, "k8s api client failed to create")
-	}
-
-	if err := api.CreateO7tClient(viperConfig.GetString("ClusterName")); err != nil {
-		return errors.Wrap(err, "OpenShift api client failed to create")
 	}
 
 	return nil

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -125,6 +125,10 @@ func surveyMissingValues() error {
 		viperConfig.Set("FetchFromRemote", true)
 	}
 
+	if err := surveyTargetCluster(); err != nil {
+		return err
+	}
+
 	if viperConfig.GetString("WorkDir") == "" {
 		workDir := "."
 		prompt := &survey.Input{
@@ -138,14 +142,23 @@ func surveyMissingValues() error {
 		viperConfig.Set("WorkDir", workDir)
 	}
 
-	if err := api.CreateK8sClient(viperConfig.GetString("ClusterName")); err != nil {
+	srcClusterName := viperConfig.GetString("ClusterName")
+	// set current context to selected cluster for cclient-go
+	api.KubeConfig.CurrentContext = api.ClusterNames[srcClusterName]
+	if err := api.CreateK8sClient(srcClusterName); err != nil {
 		return errors.Wrap(err, "k8s api client failed to create")
 	}
-
-	if err := api.CreateO7tClient(viperConfig.GetString("ClusterName")); err != nil {
+	if err := api.CreateO7tClient(srcClusterName); err != nil {
 		return errors.Wrap(err, "OpenShift api client failed to create")
 	}
 
+	dstClusterName := viperConfig.GetString("TargetClusterName")
+	if viperConfig.GetString("TargetCluster") == "true" && dstClusterName != "" {
+		api.KubeConfig.CurrentContext = api.ClusterNames[dstClusterName]
+		if err := api.CreateK8sDstClient(dstClusterName); err != nil {
+			return errors.Wrap(err, "k8s api client failed to create for destination cluster")
+		}
+	}
 	return nil
 }
 
@@ -252,6 +265,33 @@ func surveyHostname() error {
 		viperConfig.Set("Hostname", hostname)
 	}
 
+	return nil
+}
+
+func surveyTargetCluster() error {
+	targetCluster := viperConfig.GetString("TargetCluster")
+
+	if !viperConfig.InConfig("Target") && targetCluster == "" {
+		prompt := &survey.Select{
+			Message: "Do you wish to use target cluster?",
+			Options: []string{"true", "false"},
+		}
+		if err := survey.AskOne(prompt, &targetCluster); err != nil {
+			return err
+		}
+
+		if targetCluster == "true" {
+			clusterName := ""
+			var err error
+
+			if clusterName, err = clusterdiscovery.DiscoverDstCluster(); err == nil {
+				viperConfig.Set("TargetCluster", targetCluster)
+				viperConfig.Set("TargetClusterName", clusterName)
+			} else {
+				return err
+			}
+		}
+	}
 	return nil
 }
 

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -19,6 +19,8 @@ func TestInitConfig(t *testing.T) {
 	os.Setenv("CPMA_MASTERCONFIGFILE", "dummy")
 	os.Setenv("CPMA_NODECONFIGFILE", "dummy")
 	os.Setenv("CPMA_REGISTRIESCONFIGFILE", "dummy")
+	os.Setenv("CPMA_TARGETCLUSTER", "false")
+	os.Setenv("CPMA_TARGETCLUSTERNAME", "")
 
 	ConfigFile = "testdata/cpma-config.yml"
 	api.K8sClient = &kubernetes.Clientset{}
@@ -119,6 +121,8 @@ func TestInitFromEnv(t *testing.T) {
 			os.Setenv("CPMA_SAVECONFIG", "false")
 			os.Setenv("CPMA_SILENT", "false")
 			os.Setenv("CPMA_WORKDIR", "testdata/out")
+			os.Setenv("CPMA_TARGETCLUSTER", "false")
+			os.Setenv("CPMA_TARGETCLUSTERNAME", "")
 
 			os.Setenv("CPMA_CRIOCONFIGFILE", "/etc/crio/crio.conf")
 			os.Setenv("CPMA_ETCDCONFIGFILE", "/etc/etcd/etcd.conf")

--- a/pkg/env/testdata/cpma-config.yml
+++ b/pkg/env/testdata/cpma-config.yml
@@ -1,5 +1,6 @@
 clustername: "somename"
 configsource: remote
+targetclustername: ""
 hostname: "master-0.test.example.com"
 manifests: true
 reporting: true

--- a/pkg/transform/cluster_transform.go
+++ b/pkg/transform/cluster_transform.go
@@ -173,6 +173,21 @@ func (e ClusterTransform) Extract() (Extraction, error) {
 	extraction.RBACResources.SecurityContextConstraintsList = <-chanSecurityContextConstraints
 	extraction.StorageClassList = <-chanStorageClassList
 
+	// move up
+	dstChanGVs := make(chan *metav1.APIGroupList)
+	go api.ListGroupVersions(api.K8sDstClient, dstChanGVs)
+	dstGroupVersions := filterGVs(<-dstChanGVs)
+
+	fmt.Println("src")
+	for _, g := range extraction.GroupVersions {
+		fmt.Println(g)
+	}
+
+	fmt.Println("dst")
+	for _, g := range dstGroupVersions {
+		fmt.Println(g)
+	}
+
 	return *extraction, nil
 }
 

--- a/pkg/transform/cluster_transform.go
+++ b/pkg/transform/cluster_transform.go
@@ -114,17 +114,17 @@ func (e ClusterTransform) Extract() (Extraction, error) {
 	chanStorageClassList := make(chan *k8sapistorage.StorageClassList)
 	chanSecurityContextConstraints := make(chan *o7tapisecurity.SecurityContextConstraintsList)
 
-	go api.ListGroupVersions(chanGVs)
-	go api.ListNamespaces(chanNamespaces)
-	go api.ListNodes(chanNodes)
-	go api.ListQuotas(chanClusterQuotas)
-	go api.ListPVs(chanPVs)
-	go api.ListUsers(chanUsers)
-	go api.ListGroups(chanGroups)
-	go api.ListClusterRoles(chanClusterRoles)
-	go api.ListClusterRolesBindings(chanClusterRolesListBindings)
-	go api.ListSCC(chanSecurityContextConstraints)
-	go api.ListStorageClasses(chanStorageClassList)
+	go api.ListGroupVersions(api.K8sClient, chanGVs)
+	go api.ListNamespaces(api.K8sClient, chanNamespaces)
+	go api.ListNodes(api.K8sClient, chanNodes)
+	go api.ListQuotas(api.O7tClient, chanClusterQuotas)
+	go api.ListPVs(api.K8sClient, chanPVs)
+	go api.ListUsers(api.O7tClient, chanUsers)
+	go api.ListGroups(api.O7tClient, chanGroups)
+	go api.ListClusterRoles(api.O7tClient, chanClusterRoles)
+	go api.ListClusterRolesBindings(api.O7tClient, chanClusterRolesListBindings)
+	go api.ListSCC(api.O7tClient, chanSecurityContextConstraints)
+	go api.ListStorageClasses(api.K8sClient, chanStorageClassList)
 
 	extraction := &ClusterExtraction{}
 
@@ -143,13 +143,13 @@ func (e ClusterTransform) Extract() (Extraction, error) {
 		chanRoles := make(chan *o7tapiauth.RoleList)
 		chanPVCs := make(chan *k8sapicore.PersistentVolumeClaimList)
 
-		go api.ListResourceQuotas(namespace.Name, chanQuotas)
-		go api.ListPods(namespace.Name, chanPods)
-		go api.ListRoutes(namespace.Name, chanRoutes)
-		go api.ListDeployments(namespace.Name, chanDeployments)
-		go api.ListDaemonSets(namespace.Name, chanDaemonSets)
-		go api.ListRoles(namespace.Name, chanRoles)
-		go api.ListPVCs(namespace.Name, chanPVCs)
+		go api.ListResourceQuotas(api.K8sClient, namespace.Name, chanQuotas)
+		go api.ListPods(api.K8sClient, namespace.Name, chanPods)
+		go api.ListRoutes(api.O7tClient, namespace.Name, chanRoutes)
+		go api.ListDeployments(api.K8sClient, namespace.Name, chanDeployments)
+		go api.ListDaemonSets(api.K8sClient, namespace.Name, chanDaemonSets)
+		go api.ListRoles(api.O7tClient, namespace.Name, chanRoles)
+		go api.ListPVCs(api.K8sClient, namespace.Name, chanPVCs)
 
 		namespaceResources.ResourceQuotaList = <-chanQuotas
 		namespaceResources.PodList = <-chanPods

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -34,6 +34,7 @@ func TestReport(t *testing.T) {
 	os.Chdir("../..")
 	os.Setenv("CPMA_CONFIGSOURCE", "remote")
 	os.Setenv("CPMA_CRIOCONFIGFILE", "/etc/crio/crio.conf")
+	os.Setenv("CPMA_DESTINATION", "false")
 	os.Setenv("CPMA_ETCDCONFIGFILE", "/etc/etcd/etcd.conf")
 	os.Setenv("CPMA_INSECUREHOSTKEY", "true")
 	os.Setenv("CPMA_MANIFESTS", "true")
@@ -84,6 +85,8 @@ func TestManifestsReporting(t *testing.T) {
 	os.Setenv("CPMA_REGISTRIESCONFIGFILE", "/etc/containers/registries.conf")
 	os.Setenv("CPMA_SAVECONFIG", "false")
 	os.Setenv("CPMA_WORKDIR", e2eTestOut)
+	os.Setenv("CPMA_TARGETCLUSTER", "false")
+	os.Setenv("CPMA_TARGETCLUSTERNAME", "")
 
 	err = runCpma()
 	assert.NoError(t, err, "Couldn't execute CPMA")


### PR DESCRIPTION
- Makes API requests independent of client by passing the client set as paramater
- Adds survey to add destination cluster based on Kubeconfig config
- Creates destination cluster by swapping kubeconfig context