### PR TITLE
Reports source cluster missing GroupVersions compared to target cluster

### DIFF
--- a/pkg/api/requests.go
+++ b/pkg/api/requests.go
@@ -18,14 +18,15 @@ import (
 
 // Resources represent api resources used in report
 type Resources struct {
-	GroupVersions        []string
+	GroupVersions        *metav1.APIGroupList
+	DstGroupVersions     *metav1.APIGroupList
 	QuotaList            *o7tapiquota.ClusterResourceQuotaList
 	NodeList             *k8sapicore.NodeList
 	PersistentVolumeList *k8sapicore.PersistentVolumeList
 	StorageClassList     *k8sapistorage.StorageClassList
 	NamespaceList        []NamespaceResources
 	RBACResources        RBACResources
-	MissingGVs           []string
+	NewGVs               []string
 }
 
 // RBACResources contains all resources related to RBAC report

--- a/pkg/api/requests.go
+++ b/pkg/api/requests.go
@@ -25,6 +25,7 @@ type Resources struct {
 	StorageClassList     *k8sapistorage.StorageClassList
 	NamespaceList        []NamespaceResources
 	RBACResources        RBACResources
+	MissingGVs           []string
 }
 
 // RBACResources contains all resources related to RBAC report

--- a/pkg/transform/cluster/cluster.go
+++ b/pkg/transform/cluster/cluster.go
@@ -26,7 +26,7 @@ type Report struct {
 	PVs            []PVReport           `json:"pvs,omitempty"`
 	StorageClasses []StorageClassReport `json:"storageClasses,omitempty"`
 	RBACReport     RBACReport           `json:"rbacreport,omitempty"`
-	MissingGVs     []MissingGVsReport   `json:"missingGVs,omitempty"`
+	NewGVs         []NewGVsReport       `json:"newGroupVersions,omitempty"`
 }
 
 // NodeReport represents json report of k8s nodes
@@ -135,8 +135,8 @@ type RBACReport struct {
 	SecurityContextConstraints []OpenshiftSecurityContextConstraints `json:"securityContextConstraints"`
 }
 
-// MissingGVsReport represents json report of k8s storage classes
-type MissingGVsReport struct {
+// NewGVsReport represents json report of k8s storage classes
+type NewGVsReport struct {
 	GroupVersion string `json:"groupversion"`
 }
 
@@ -207,7 +207,7 @@ func GenClusterReport(apiResources api.Resources) (clusterReport Report) {
 	clusterReport.ReportNodes(apiResources)
 	clusterReport.ReportRBAC(apiResources)
 	clusterReport.ReportStorageClasses(apiResources)
-	clusterReport.ReportMissingGVs(apiResources.MissingGVs)
+	clusterReport.ReportNewGVs(apiResources.NewGVs)
 	return
 }
 
@@ -570,15 +570,15 @@ func (clusterReport *Report) ReportStorageClasses(apiResources api.Resources) {
 	}
 }
 
-// ReportMissingGVs reports GroupVersion present in target but in source cluster
-func (clusterReport *Report) ReportMissingGVs(missingList []string) {
-	logrus.Info("ClusterReport::ReportMissingGVs")
-	for _, groupVersion := range missingList {
-		reportedMissingGVs := MissingGVsReport{
+// ReportNewGVs reports GroupVersion present in target but in source cluster
+func (clusterReport *Report) ReportNewGVs(list []string) {
+	logrus.Info("ClusterReport::ReportNewGVs")
+	for _, groupVersion := range list {
+		reportedNewGVs := NewGVsReport{
 			GroupVersion: groupVersion,
 		}
 
-		clusterReport.MissingGVs = append(clusterReport.MissingGVs, reportedMissingGVs)
+		clusterReport.NewGVs = append(clusterReport.NewGVs, reportedNewGVs)
 	}
 }
 

--- a/pkg/transform/cluster/cluster.go
+++ b/pkg/transform/cluster/cluster.go
@@ -26,6 +26,7 @@ type Report struct {
 	PVs            []PVReport           `json:"pvs,omitempty"`
 	StorageClasses []StorageClassReport `json:"storageClasses,omitempty"`
 	RBACReport     RBACReport           `json:"rbacreport,omitempty"`
+	MissingGVs     []MissingGVsReport   `json:"missingGVs,omitempty"`
 }
 
 // NodeReport represents json report of k8s nodes
@@ -134,6 +135,11 @@ type RBACReport struct {
 	SecurityContextConstraints []OpenshiftSecurityContextConstraints `json:"securityContextConstraints"`
 }
 
+// MissingGVsReport represents json report of k8s storage classes
+type MissingGVsReport struct {
+	GroupVersion string `json:"groupversion"`
+}
+
 // OpenshiftUser wrapper around openshift user
 type OpenshiftUser struct {
 	Name       string   `json:"name"`
@@ -201,6 +207,7 @@ func GenClusterReport(apiResources api.Resources) (clusterReport Report) {
 	clusterReport.ReportNodes(apiResources)
 	clusterReport.ReportRBAC(apiResources)
 	clusterReport.ReportStorageClasses(apiResources)
+	clusterReport.ReportMissingGVs(apiResources.MissingGVs)
 	return
 }
 
@@ -560,6 +567,18 @@ func (clusterReport *Report) ReportStorageClasses(apiResources api.Resources) {
 		}
 
 		clusterReport.StorageClasses = append(clusterReport.StorageClasses, reportedStorageClass)
+	}
+}
+
+// ReportMissingGVs reports GroupVersion present in target but in source cluster
+func (clusterReport *Report) ReportMissingGVs(missingList []string) {
+	logrus.Info("ClusterReport::ReportMissingGVs")
+	for _, groupVersion := range missingList {
+		reportedMissingGVs := MissingGVsReport{
+			GroupVersion: groupVersion,
+		}
+
+		clusterReport.MissingGVs = append(clusterReport.MissingGVs, reportedMissingGVs)
 	}
 }
 

--- a/pkg/transform/cluster/cluster_test.go
+++ b/pkg/transform/cluster/cluster_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/fusor/cpma/pkg/api"
+	"github.com/fusor/cpma/pkg/transform"
 	"github.com/fusor/cpma/pkg/transform/cluster"
 	cpmatest "github.com/fusor/cpma/pkg/transform/internal/test"
 	o7tapiauth "github.com/openshift/api/authorization/v1"
@@ -14,7 +15,7 @@ import (
 	k8sapicore "k8s.io/api/core/v1"
 	k8sapistorage "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	k8smachinery "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestReportQuotas(t *testing.T) {
@@ -127,7 +128,7 @@ func TestReportNodes(t *testing.T) {
 	// Init fake nodes
 	nodes := make([]k8sapicore.Node, 0)
 	nodes = append(nodes, k8sapicore.Node{
-		ObjectMeta: k8smachinery.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:   "test-master",
 			Labels: masterNodeLabels,
 		},
@@ -372,7 +373,7 @@ func TestRBACReport(t *testing.T) {
 	roleList.Items = make([]o7tapiauth.Role, 0)
 
 	roleList.Items = append(roleList.Items, o7tapiauth.Role{
-		ObjectMeta: k8smachinery.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: "testrole1",
 		},
 	})
@@ -481,4 +482,33 @@ func TestRBACReport(t *testing.T) {
 		})
 	}
 
+}
+
+func TestReportMisssingGVs(t *testing.T) {
+	expectedMissingGVs := make([]cluster.NewGVsReport, 0)
+	expectedMissingGVs = append(expectedMissingGVs, cluster.NewGVsReport{
+		GroupVersion: "testgroupversion/v1",
+	})
+
+	testCases := []struct {
+		name                  string
+		inputGroupVersions    *metav1.APIGroupList
+		inputDstGroupVersions *metav1.APIGroupList
+		expectedNewGVs        []cluster.NewGVsReport
+	}{
+		{
+			name:                  "generate missing groupversions report",
+			inputGroupVersions:    cpmatest.CreateTestClusterGroupVersions("testgroupversion", "v1beta1"),
+			inputDstGroupVersions: cpmatest.CreateTestClusterGroupVersions("testgroupversion", "v1"),
+			expectedNewGVs:        expectedMissingGVs,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			clusterNewGVs := &cluster.Report{}
+			clusterNewGVs.ReportNewGVs(transform.NewGroupVersions(tc.inputGroupVersions, tc.inputDstGroupVersions))
+			assert.Equal(t, tc.expectedNewGVs, clusterNewGVs.NewGVs)
+		})
+	}
 }

--- a/pkg/transform/cluster_transform.go
+++ b/pkg/transform/cluster_transform.go
@@ -181,21 +181,29 @@ func (e ClusterTransform) Extract() (Extraction, error) {
 
 	if api.K8sDstClient != nil {
 		extraction.DstGroupVersions = <-chanDstGVs
-		newGV := []string{}
-		for _, dstGV := range filterGVs(extraction.DstGroupVersions) {
-			found := false
-			for _, srcGV := range filterGVs(extraction.GroupVersions) {
-				if dstGV == srcGV {
-					found = true
-				}
-			}
-			if found == false {
-				newGV = append(newGV, dstGV)
-			}
-		}
-		extraction.NewGVs = newGV
+		extraction.NewGVs = NewGroupVersions(extraction.GroupVersions, extraction.DstGroupVersions)
+	}
+	for _, GVs := range extraction.GroupVersions.Groups {
+		fmt.Printf("%+v\n", GVs)
 	}
 	return *extraction, nil
+}
+
+// NewGroupVersions returns the list of new GroupVersions available in destination but in source
+func NewGroupVersions(src *metav1.APIGroupList, dst *metav1.APIGroupList) []string {
+	list := []string{}
+	for _, dstGV := range filterGVs(dst) {
+		found := false
+		for _, srcGV := range filterGVs(src) {
+			if dstGV == srcGV {
+				found = true
+			}
+		}
+		if found == false {
+			list = append(list, dstGV)
+		}
+	}
+	return list
 }
 
 // Name returns a human readable name for the transform

--- a/pkg/transform/internal/test/load_cluster.go
+++ b/pkg/transform/internal/test/load_cluster.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/fusor/cpma/pkg/api"
@@ -15,7 +16,8 @@ import (
 	extv1b1 "k8s.io/api/extensions/v1beta1"
 	k8sapistorage "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	k8smachinery "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // CreateTestPVList create test pv list
@@ -43,7 +45,7 @@ func CreateTestPVList() *k8sapicore.PersistentVolumeList {
 	}
 
 	pvList.Items[0] = k8sapicore.PersistentVolume{
-		ObjectMeta: k8smachinery.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: "testpv",
 		},
 		Spec: k8sapicore.PersistentVolumeSpec{
@@ -129,7 +131,7 @@ func CreateTestNodeList() *k8sapicore.NodeList {
 	// Init fake nodes
 	nodes := make([]k8sapicore.Node, 1)
 	nodes[0] = k8sapicore.Node{
-		ObjectMeta: k8smachinery.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:   "test-master",
 			Labels: masterNodeLabels,
 		},
@@ -149,7 +151,7 @@ func CreateStorageClassList() *k8sapistorage.StorageClassList {
 	storageClassList := &k8sapistorage.StorageClassList{}
 	storageClassList.Items = make([]k8sapistorage.StorageClass, 1)
 	storageClassList.Items[0] = k8sapistorage.StorageClass{
-		ObjectMeta: k8smachinery.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: "testclass",
 		},
 		Provisioner: "testprovisioner",
@@ -164,7 +166,7 @@ func CreateTestNameSpaceList() []api.NamespaceResources {
 	roleList.Items = make([]o7tapiauth.Role, 0)
 
 	roleList.Items = append(roleList.Items, o7tapiauth.Role{
-		ObjectMeta: k8smachinery.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: "testrole1",
 		},
 	})
@@ -211,7 +213,7 @@ func CreateTestResourceQuotaList() *k8sapicore.ResourceQuotaList {
 	quotaList.Items = make([]k8sapicore.ResourceQuota, 1)
 
 	quotaList.Items[0] = k8sapicore.ResourceQuota{
-		ObjectMeta: k8smachinery.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "resourcequota1",
 			Namespace: "namespacetest1",
 		},
@@ -242,7 +244,7 @@ func CreateTestClusterQuotaList() *o7tapiquota.ClusterResourceQuotaList {
 	quotaList.Items = make([]o7tapiquota.ClusterResourceQuota, 1)
 
 	quotaList.Items[0] = o7tapiquota.ClusterResourceQuota{
-		ObjectMeta: k8smachinery.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-quota1",
 		},
 		Spec: o7tapiquota.ClusterResourceQuotaSpec{
@@ -263,16 +265,16 @@ func CreateTestPodList() *k8sapicore.PodList {
 	podList.Items = make([]k8sapicore.Pod, 2)
 	timeStamp, _ := time.Parse(time.RFC1123Z, "Tue, 17 Nov 2009 21:34:58 +0100")
 	podList.Items[0] = k8sapicore.Pod{
-		ObjectMeta: k8smachinery.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:              "test-pod1",
-			CreationTimestamp: k8smachinery.NewTime(timeStamp),
+			CreationTimestamp: metav1.NewTime(timeStamp),
 		},
 	}
 
 	podList.Items[1] = k8sapicore.Pod{
-		ObjectMeta: k8smachinery.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:              "test-pod2",
-			CreationTimestamp: k8smachinery.NewTime(timeStamp),
+			CreationTimestamp: metav1.NewTime(timeStamp),
 		},
 	}
 
@@ -300,7 +302,7 @@ func CreateTestRouteList() *o7tapiroute.RouteList {
 	}
 
 	routeList.Items[0] = o7tapiroute.Route{
-		ObjectMeta: k8smachinery.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: "route1",
 		},
 		Spec: o7tapiroute.RouteSpec{
@@ -324,9 +326,9 @@ func CreateDeploymentList() *v1beta1.DeploymentList {
 	deployment := v1beta1.Deployment{}
 
 	timestamp, _ := time.Parse(time.RFC1123Z, "Sun, 07 Jul 2019 09:45:35 +0100")
-	deployment.ObjectMeta = k8smachinery.ObjectMeta{
+	deployment.ObjectMeta = metav1.ObjectMeta{
 		Name:              "testDeployment",
-		CreationTimestamp: k8smachinery.NewTime(timestamp),
+		CreationTimestamp: metav1.NewTime(timestamp),
 	}
 	deploymentList.Items[0] = deployment
 
@@ -341,9 +343,9 @@ func CreateDaemonSetList() *extv1b1.DaemonSetList {
 	daemonSet := extv1b1.DaemonSet{}
 
 	timestamp, _ := time.Parse(time.RFC1123Z, "Sun, 07 Jul 2019 09:45:35 +0100")
-	daemonSet.ObjectMeta = k8smachinery.ObjectMeta{
+	daemonSet.ObjectMeta = metav1.ObjectMeta{
 		Name:              "testDaemonSet",
-		CreationTimestamp: k8smachinery.NewTime(timestamp),
+		CreationTimestamp: metav1.NewTime(timestamp),
 	}
 	daemonSetList.Items[0] = daemonSet
 
@@ -394,7 +396,7 @@ func CreateUserList() *o7tapiuser.UserList {
 	userList.Items = make([]o7tapiuser.User, 0)
 
 	userList.Items = append(userList.Items, o7tapiuser.User{
-		ObjectMeta: k8smachinery.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: "testuser1",
 		},
 		FullName:   "full name1",
@@ -403,7 +405,7 @@ func CreateUserList() *o7tapiuser.UserList {
 	})
 
 	userList.Items = append(userList.Items, o7tapiuser.User{
-		ObjectMeta: k8smachinery.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: "testuser2",
 		},
 		FullName:   "full name2",
@@ -420,14 +422,14 @@ func CreateGroupList() *o7tapiuser.GroupList {
 	groupList.Items = make([]o7tapiuser.Group, 0)
 
 	groupList.Items = append(groupList.Items, o7tapiuser.Group{
-		ObjectMeta: k8smachinery.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: "testgroup1",
 		},
 		Users: []string{"testuser1"},
 	})
 
 	groupList.Items = append(groupList.Items, o7tapiuser.Group{
-		ObjectMeta: k8smachinery.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: "testgroup2",
 		},
 		Users: []string{"testuser2"},
@@ -442,7 +444,7 @@ func CreateClusterRoleList() *o7tapiauth.ClusterRoleList {
 	clusterRoleList.Items = make([]o7tapiauth.ClusterRole, 0)
 
 	clusterRoleList.Items = append(clusterRoleList.Items, o7tapiauth.ClusterRole{
-		ObjectMeta: k8smachinery.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: "testrole1",
 		},
 	})
@@ -456,7 +458,7 @@ func CreateClusterRoleBindingsList() *o7tapiauth.ClusterRoleBindingList {
 	clusterRoleBindingsList.Items = make([]o7tapiauth.ClusterRoleBinding, 0)
 
 	clusterRoleBindingsList.Items = append(clusterRoleBindingsList.Items, o7tapiauth.ClusterRoleBinding{
-		ObjectMeta: k8smachinery.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: "testbinding1",
 		},
 		UserNames:  []string{"testuser1"},
@@ -471,7 +473,7 @@ func CreateSCCList() *o7tapisecurity.SecurityContextConstraintsList {
 	sccList.Items = make([]o7tapisecurity.SecurityContextConstraints, 0)
 
 	sccList.Items = append(sccList.Items, o7tapisecurity.SecurityContextConstraints{
-		ObjectMeta: k8smachinery.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: "testscc1",
 		},
 		Users:  []string{"testuser1", "testrole:serviceaccount:testnamespace1:testsa"},
@@ -488,7 +490,7 @@ func CreatePVCList() *k8sapicore.PersistentVolumeClaimList {
 
 	storageClass := "teststorageclass"
 	pvcList.Items = append(pvcList.Items, k8sapicore.PersistentVolumeClaim{
-		ObjectMeta: k8smachinery.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: "testPVC",
 		},
 		Spec: k8sapicore.PersistentVolumeClaimSpec{
@@ -499,4 +501,28 @@ func CreatePVCList() *k8sapicore.PersistentVolumeClaimList {
 	})
 
 	return pvcList
+}
+
+// CreateTestClusterGroupVersions test for GroupVersionList
+func CreateTestClusterGroupVersions(group string, version string) *metav1.APIGroupList {
+	groupList := &metav1.APIGroupList{}
+	groupList.Groups = make([]metav1.APIGroup, 1)
+
+	groupList.Groups[0] = metav1.APIGroup{
+		TypeMeta: v1.TypeMeta{
+			Kind:       "",
+			APIVersion: "",
+		},
+		Name: group,
+		Versions: []metav1.GroupVersionForDiscovery{
+			{GroupVersion: fmt.Sprintf("%s/%s", group, version),
+				Version: version},
+		},
+		PreferredVersion: metav1.GroupVersionForDiscovery{
+			GroupVersion: fmt.Sprintf("%s/%s", group, version),
+			Version:      version,
+		},
+	}
+
+	return groupList
 }


### PR DESCRIPTION
When using a target Cluster, reports the GroupVersions available in target but not in the source cluster:

  ```golang
"newGroupVersions": [
   {
    "groupversion": "apiregistration.k8s.io/v1"
   },
   {
    "groupversion": "apps/v1"
   },
   {
    "groupversion": "apps/v1beta2"
   },
   {
    "groupversion": "events.k8s.io/v1beta1"
   },
   {
    "groupversion": "autoscaling/v2beta1"
   },
   {
    "groupversion": "autoscaling/v2beta2"
   },
...<snip>...
   {
    "groupversion": "machine.openshift.io/v1beta1"
   },
   {
    "groupversion": "metrics.k8s.io/v1beta1"
   }```