### PR TITLE
Cleanse survey hostname api (#431)

### DIFF
--- a/pkg/env/clusterdiscovery/clusterdiscovery.go
+++ b/pkg/env/clusterdiscovery/clusterdiscovery.go
@@ -22,10 +22,6 @@ func DiscoverCluster() (string, string, error) {
 		return "", "", errors.Wrap(err, "k8s api client failed to create")
 	}
 
-	if err := api.CreateO7tClient(selectedCluster); err != nil {
-		return "", "", errors.Wrap(err, "openshift api client failed to create")
-	}
-
 	clusterNodes, err := queryNodes(api.K8sClient.CoreV1())
 	if err != nil {
 		return "", "", errors.Wrap(err, "cluster node query failed")


### PR DESCRIPTION
* run surveyHostname first to simplify

* Cluster name is prompted only when not using Kubeconfig

* Remove unused and not needed code

(cherry picked from commit 51c9cfffc5a12f159fbee8d2b4de15ce966c2d92)