### PR TITLE
Revert "Reports source cluster missing GroupVersions compared to target cluster (#438)"

### DIFF
--- a/pkg/api/requests.go
+++ b/pkg/api/requests.go
@@ -18,7 +18,7 @@ import (
 
 // Resources represent api resources used in report
 type Resources struct {
-	GroupVersions        *metav1.APIGroupList
+	GroupVersions        []string
 	DstGroupVersions     *metav1.APIGroupList
 	QuotaList            *o7tquotav1.ClusterResourceQuotaList
 	NodeList             *corev1.NodeList
@@ -26,7 +26,6 @@ type Resources struct {
 	StorageClassList     *storagev1.StorageClassList
 	NamespaceList        []NamespaceResources
 	RBACResources        RBACResources
-	NewGVs               []string
 }
 
 // RBACResources contains all resources related to RBAC report

--- a/pkg/transform/cluster/cluster.go
+++ b/pkg/transform/cluster/cluster.go
@@ -26,7 +26,6 @@ type Report struct {
 	PVs            []PVReport           `json:"pvs,omitempty"`
 	StorageClasses []StorageClassReport `json:"storageClasses,omitempty"`
 	RBACReport     RBACReport           `json:"rbacreport,omitempty"`
-	NewGVs         []NewGVsReport       `json:"newGroupVersions,omitempty"`
 }
 
 // NodeReport represents json report of k8s nodes
@@ -135,11 +134,6 @@ type RBACReport struct {
 	SecurityContextConstraints []OpenshiftSecurityContextConstraints `json:"securityContextConstraints"`
 }
 
-// NewGVsReport represents json report of k8s storage classes
-type NewGVsReport struct {
-	GroupVersion string `json:"groupversion"`
-}
-
 // OpenshiftUser wrapper around openshift user
 type OpenshiftUser struct {
 	Name       string   `json:"name"`
@@ -207,7 +201,6 @@ func GenClusterReport(apiResources api.Resources) (clusterReport Report) {
 	clusterReport.ReportNodes(apiResources)
 	clusterReport.ReportRBAC(apiResources)
 	clusterReport.ReportStorageClasses(apiResources)
-	clusterReport.ReportNewGVs(apiResources.NewGVs)
 	return
 }
 
@@ -567,18 +560,6 @@ func (clusterReport *Report) ReportStorageClasses(apiResources api.Resources) {
 		}
 
 		clusterReport.StorageClasses = append(clusterReport.StorageClasses, reportedStorageClass)
-	}
-}
-
-// ReportNewGVs reports GroupVersion present in target but in source cluster
-func (clusterReport *Report) ReportNewGVs(list []string) {
-	logrus.Info("ClusterReport::ReportNewGVs")
-	for _, groupVersion := range list {
-		reportedNewGVs := NewGVsReport{
-			GroupVersion: groupVersion,
-		}
-
-		clusterReport.NewGVs = append(clusterReport.NewGVs, reportedNewGVs)
 	}
 }
 

--- a/pkg/transform/cluster/cluster_test.go
+++ b/pkg/transform/cluster/cluster_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/fusor/cpma/pkg/api"
-	"github.com/fusor/cpma/pkg/transform"
 	"github.com/fusor/cpma/pkg/transform/cluster"
 	cpmatest "github.com/fusor/cpma/pkg/transform/internal/test"
 	o7tapiauth "github.com/openshift/api/authorization/v1"
@@ -15,7 +14,7 @@ import (
 	k8sapicore "k8s.io/api/core/v1"
 	k8sapistorage "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8smachinery "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestReportQuotas(t *testing.T) {
@@ -128,7 +127,7 @@ func TestReportNodes(t *testing.T) {
 	// Init fake nodes
 	nodes := make([]k8sapicore.Node, 0)
 	nodes = append(nodes, k8sapicore.Node{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: k8smachinery.ObjectMeta{
 			Name:   "test-master",
 			Labels: masterNodeLabels,
 		},
@@ -373,7 +372,7 @@ func TestRBACReport(t *testing.T) {
 	roleList.Items = make([]o7tapiauth.Role, 0)
 
 	roleList.Items = append(roleList.Items, o7tapiauth.Role{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: k8smachinery.ObjectMeta{
 			Name: "testrole1",
 		},
 	})
@@ -482,33 +481,4 @@ func TestRBACReport(t *testing.T) {
 		})
 	}
 
-}
-
-func TestReportMisssingGVs(t *testing.T) {
-	expectedMissingGVs := make([]cluster.NewGVsReport, 0)
-	expectedMissingGVs = append(expectedMissingGVs, cluster.NewGVsReport{
-		GroupVersion: "testgroupversion/v1",
-	})
-
-	testCases := []struct {
-		name                  string
-		inputGroupVersions    *metav1.APIGroupList
-		inputDstGroupVersions *metav1.APIGroupList
-		expectedNewGVs        []cluster.NewGVsReport
-	}{
-		{
-			name:                  "generate missing groupversions report",
-			inputGroupVersions:    cpmatest.CreateTestClusterGroupVersions("testgroupversion", "v1beta1"),
-			inputDstGroupVersions: cpmatest.CreateTestClusterGroupVersions("testgroupversion", "v1"),
-			expectedNewGVs:        expectedMissingGVs,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			clusterNewGVs := &cluster.Report{}
-			clusterNewGVs.ReportNewGVs(transform.NewGroupVersions(tc.inputGroupVersions, tc.inputDstGroupVersions))
-			assert.Equal(t, tc.expectedNewGVs, clusterNewGVs.NewGVs)
-		})
-	}
 }

--- a/pkg/transform/internal/test/load_cluster.go
+++ b/pkg/transform/internal/test/load_cluster.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/fusor/cpma/pkg/api"
@@ -16,8 +15,7 @@ import (
 	extv1b1 "k8s.io/api/extensions/v1beta1"
 	k8sapistorage "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8smachinery "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // CreateTestPVList create test pv list
@@ -45,7 +43,7 @@ func CreateTestPVList() *k8sapicore.PersistentVolumeList {
 	}
 
 	pvList.Items[0] = k8sapicore.PersistentVolume{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: k8smachinery.ObjectMeta{
 			Name: "testpv",
 		},
 		Spec: k8sapicore.PersistentVolumeSpec{
@@ -131,7 +129,7 @@ func CreateTestNodeList() *k8sapicore.NodeList {
 	// Init fake nodes
 	nodes := make([]k8sapicore.Node, 1)
 	nodes[0] = k8sapicore.Node{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: k8smachinery.ObjectMeta{
 			Name:   "test-master",
 			Labels: masterNodeLabels,
 		},
@@ -151,7 +149,7 @@ func CreateStorageClassList() *k8sapistorage.StorageClassList {
 	storageClassList := &k8sapistorage.StorageClassList{}
 	storageClassList.Items = make([]k8sapistorage.StorageClass, 1)
 	storageClassList.Items[0] = k8sapistorage.StorageClass{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: k8smachinery.ObjectMeta{
 			Name: "testclass",
 		},
 		Provisioner: "testprovisioner",
@@ -166,7 +164,7 @@ func CreateTestNameSpaceList() []api.NamespaceResources {
 	roleList.Items = make([]o7tapiauth.Role, 0)
 
 	roleList.Items = append(roleList.Items, o7tapiauth.Role{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: k8smachinery.ObjectMeta{
 			Name: "testrole1",
 		},
 	})
@@ -213,7 +211,7 @@ func CreateTestResourceQuotaList() *k8sapicore.ResourceQuotaList {
 	quotaList.Items = make([]k8sapicore.ResourceQuota, 1)
 
 	quotaList.Items[0] = k8sapicore.ResourceQuota{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: k8smachinery.ObjectMeta{
 			Name:      "resourcequota1",
 			Namespace: "namespacetest1",
 		},
@@ -244,7 +242,7 @@ func CreateTestClusterQuotaList() *o7tapiquota.ClusterResourceQuotaList {
 	quotaList.Items = make([]o7tapiquota.ClusterResourceQuota, 1)
 
 	quotaList.Items[0] = o7tapiquota.ClusterResourceQuota{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: k8smachinery.ObjectMeta{
 			Name: "test-quota1",
 		},
 		Spec: o7tapiquota.ClusterResourceQuotaSpec{
@@ -265,16 +263,16 @@ func CreateTestPodList() *k8sapicore.PodList {
 	podList.Items = make([]k8sapicore.Pod, 2)
 	timeStamp, _ := time.Parse(time.RFC1123Z, "Tue, 17 Nov 2009 21:34:58 +0100")
 	podList.Items[0] = k8sapicore.Pod{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: k8smachinery.ObjectMeta{
 			Name:              "test-pod1",
-			CreationTimestamp: metav1.NewTime(timeStamp),
+			CreationTimestamp: k8smachinery.NewTime(timeStamp),
 		},
 	}
 
 	podList.Items[1] = k8sapicore.Pod{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: k8smachinery.ObjectMeta{
 			Name:              "test-pod2",
-			CreationTimestamp: metav1.NewTime(timeStamp),
+			CreationTimestamp: k8smachinery.NewTime(timeStamp),
 		},
 	}
 
@@ -302,7 +300,7 @@ func CreateTestRouteList() *o7tapiroute.RouteList {
 	}
 
 	routeList.Items[0] = o7tapiroute.Route{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: k8smachinery.ObjectMeta{
 			Name: "route1",
 		},
 		Spec: o7tapiroute.RouteSpec{
@@ -326,9 +324,9 @@ func CreateDeploymentList() *v1beta1.DeploymentList {
 	deployment := v1beta1.Deployment{}
 
 	timestamp, _ := time.Parse(time.RFC1123Z, "Sun, 07 Jul 2019 09:45:35 +0100")
-	deployment.ObjectMeta = metav1.ObjectMeta{
+	deployment.ObjectMeta = k8smachinery.ObjectMeta{
 		Name:              "testDeployment",
-		CreationTimestamp: metav1.NewTime(timestamp),
+		CreationTimestamp: k8smachinery.NewTime(timestamp),
 	}
 	deploymentList.Items[0] = deployment
 
@@ -343,9 +341,9 @@ func CreateDaemonSetList() *extv1b1.DaemonSetList {
 	daemonSet := extv1b1.DaemonSet{}
 
 	timestamp, _ := time.Parse(time.RFC1123Z, "Sun, 07 Jul 2019 09:45:35 +0100")
-	daemonSet.ObjectMeta = metav1.ObjectMeta{
+	daemonSet.ObjectMeta = k8smachinery.ObjectMeta{
 		Name:              "testDaemonSet",
-		CreationTimestamp: metav1.NewTime(timestamp),
+		CreationTimestamp: k8smachinery.NewTime(timestamp),
 	}
 	daemonSetList.Items[0] = daemonSet
 
@@ -396,7 +394,7 @@ func CreateUserList() *o7tapiuser.UserList {
 	userList.Items = make([]o7tapiuser.User, 0)
 
 	userList.Items = append(userList.Items, o7tapiuser.User{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: k8smachinery.ObjectMeta{
 			Name: "testuser1",
 		},
 		FullName:   "full name1",
@@ -405,7 +403,7 @@ func CreateUserList() *o7tapiuser.UserList {
 	})
 
 	userList.Items = append(userList.Items, o7tapiuser.User{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: k8smachinery.ObjectMeta{
 			Name: "testuser2",
 		},
 		FullName:   "full name2",
@@ -422,14 +420,14 @@ func CreateGroupList() *o7tapiuser.GroupList {
 	groupList.Items = make([]o7tapiuser.Group, 0)
 
 	groupList.Items = append(groupList.Items, o7tapiuser.Group{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: k8smachinery.ObjectMeta{
 			Name: "testgroup1",
 		},
 		Users: []string{"testuser1"},
 	})
 
 	groupList.Items = append(groupList.Items, o7tapiuser.Group{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: k8smachinery.ObjectMeta{
 			Name: "testgroup2",
 		},
 		Users: []string{"testuser2"},
@@ -444,7 +442,7 @@ func CreateClusterRoleList() *o7tapiauth.ClusterRoleList {
 	clusterRoleList.Items = make([]o7tapiauth.ClusterRole, 0)
 
 	clusterRoleList.Items = append(clusterRoleList.Items, o7tapiauth.ClusterRole{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: k8smachinery.ObjectMeta{
 			Name: "testrole1",
 		},
 	})
@@ -458,7 +456,7 @@ func CreateClusterRoleBindingsList() *o7tapiauth.ClusterRoleBindingList {
 	clusterRoleBindingsList.Items = make([]o7tapiauth.ClusterRoleBinding, 0)
 
 	clusterRoleBindingsList.Items = append(clusterRoleBindingsList.Items, o7tapiauth.ClusterRoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: k8smachinery.ObjectMeta{
 			Name: "testbinding1",
 		},
 		UserNames:  []string{"testuser1"},
@@ -473,7 +471,7 @@ func CreateSCCList() *o7tapisecurity.SecurityContextConstraintsList {
 	sccList.Items = make([]o7tapisecurity.SecurityContextConstraints, 0)
 
 	sccList.Items = append(sccList.Items, o7tapisecurity.SecurityContextConstraints{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: k8smachinery.ObjectMeta{
 			Name: "testscc1",
 		},
 		Users:  []string{"testuser1", "testrole:serviceaccount:testnamespace1:testsa"},
@@ -490,7 +488,7 @@ func CreatePVCList() *k8sapicore.PersistentVolumeClaimList {
 
 	storageClass := "teststorageclass"
 	pvcList.Items = append(pvcList.Items, k8sapicore.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
+		ObjectMeta: k8smachinery.ObjectMeta{
 			Name: "testPVC",
 		},
 		Spec: k8sapicore.PersistentVolumeClaimSpec{
@@ -501,28 +499,4 @@ func CreatePVCList() *k8sapicore.PersistentVolumeClaimList {
 	})
 
 	return pvcList
-}
-
-// CreateTestClusterGroupVersions test for GroupVersionList
-func CreateTestClusterGroupVersions(group string, version string) *metav1.APIGroupList {
-	groupList := &metav1.APIGroupList{}
-	groupList.Groups = make([]metav1.APIGroup, 1)
-
-	groupList.Groups[0] = metav1.APIGroup{
-		TypeMeta: v1.TypeMeta{
-			Kind:       "",
-			APIVersion: "",
-		},
-		Name: group,
-		Versions: []metav1.GroupVersionForDiscovery{
-			{GroupVersion: fmt.Sprintf("%s/%s", group, version),
-				Version: version},
-		},
-		PreferredVersion: metav1.GroupVersionForDiscovery{
-			GroupVersion: fmt.Sprintf("%s/%s", group, version),
-			Version:      version,
-		},
-	}
-
-	return groupList
 }


### PR DESCRIPTION
This reverts commit a699918a7b11382b95d56616eb8d5fbea048c41f.

Removing discovery and GroupVersion reporting which are an unsupported feature.