### PR TITLE
Revert "Remove debug fmt (#439)"

### DIFF
--- a/pkg/transform/cluster_transform.go
+++ b/pkg/transform/cluster_transform.go
@@ -183,7 +183,9 @@ func (e ClusterTransform) Extract() (Extraction, error) {
 		extraction.DstGroupVersions = <-chanDstGVs
 		extraction.NewGVs = NewGroupVersions(extraction.GroupVersions, extraction.DstGroupVersions)
 	}
-
+	for _, GVs := range extraction.GroupVersions.Groups {
+		fmt.Printf("%+v\n", GVs)
+	}
 	return *extraction, nil
 }
 


### PR DESCRIPTION
This reverts commit 2b69781d61e24f2d4a701cc6f7eca639679a468c.

Removing discovery and GroupVersion reporting which are an unsupported feature.