### PR TITLE
Revert "Discover dst cluster extra test and cleanup (#437)"

### DIFF
--- a/pkg/env/clusterdiscovery/clusterdiscovery.go
+++ b/pkg/env/clusterdiscovery/clusterdiscovery.go
@@ -12,11 +12,7 @@ import (
 // DiscoverDstCluster Get kubeconfig using $KUBECONFIG, if not try ~/.kube/config
 // parse kubeconfig and select targeted cluster from available contexts
 func DiscoverDstCluster() (string, error) {
-	selectedCluster := SurveyClusters()
-	if selectedCluster != "" {
-		return "", nil
-	}
-	return selectedCluster, nil
+	return SurveyClusters(), nil
 }
 
 // DiscoverCluster Get kubeconfig using $KUBECONFIG, if not try ~/.kube/config

--- a/pkg/transform/cluster_transform.go
+++ b/pkg/transform/cluster_transform.go
@@ -173,6 +173,21 @@ func (e ClusterTransform) Extract() (Extraction, error) {
 	extraction.RBACResources.SecurityContextConstraintsList = <-chanSecurityContextConstraints
 	extraction.StorageClassList = <-chanStorageClassList
 
+	// move up
+	dstChanGVs := make(chan *metav1.APIGroupList)
+	go api.ListGroupVersions(api.K8sDstClient, dstChanGVs)
+	dstGroupVersions := filterGVs(<-dstChanGVs)
+
+	fmt.Println("src")
+	for _, g := range extraction.GroupVersions {
+		fmt.Println(g)
+	}
+
+	fmt.Println("dst")
+	for _, g := range dstGroupVersions {
+		fmt.Println(g)
+	}
+
 	return *extraction, nil
 }
 


### PR DESCRIPTION
This reverts commit d9aa635542a6cdd6bf337139d2ec2a3bd45408f5.

Removing discovery and GroupVersion reporting which are an unsupported feature.