### PR TITLE
Revert "Discovery is included in k8s client (#435)"

### DIFF
--- a/pkg/api/initclient.go
+++ b/pkg/api/initclient.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -27,6 +28,8 @@ var (
 	K8sDstClient *kubernetes.Clientset
 	// O7tClient openshift api client for source cluster
 	O7tClient *OpenshiftClient
+	// Discovery client
+	Discovery *discovery.DiscoveryClient
 
 	kubeConfigGetter = func() (*clientcmdapi.Config, error) {
 		return KubeConfig, nil
@@ -75,16 +78,16 @@ func getKubeConfigPath() (string, error) {
 	return kubeConfigPath, nil
 }
 
-// CreateK8sDstClient create api client using cluster from kubeconfig context
-func CreateK8sDstClient(contextCluster string) error {
-	if K8sDstClient == nil {
-		config, err := buildConfig(contextCluster)
-		if err != nil {
-			return err
-		}
+// CreateDiscoveryClient create api client using cluster from kubeconfig context
+func CreateDiscoveryClient(contextCluster string) error {
+	config, err := buildConfig(contextCluster)
+	if err != nil {
+		return err
+	}
 
-		K8sDstClient = NewK8SOrDie(config)
-		logrus.Debugf("Kubernetes API client initialized for %s", contextCluster)
+	if Discovery == nil {
+		Discovery = NewDiscoveryOrDie(config)
+		logrus.Debugf("Discovery API client initialized for %s", contextCluster)
 	}
 
 	return nil

--- a/pkg/api/k8s.go
+++ b/pkg/api/k8s.go
@@ -1,9 +1,15 @@
 package api
 
 import (
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
+
+// NewDiscoveryOrDie init k8s client or panic
+func NewDiscoveryOrDie(config *rest.Config) *discovery.DiscoveryClient {
+	return discovery.NewDiscoveryClientForConfigOrDie(config)
+}
 
 // NewK8SOrDie init k8s client or panic
 func NewK8SOrDie(config *rest.Config) *kubernetes.Clientset {

--- a/pkg/api/requests.go
+++ b/pkg/api/requests.go
@@ -53,7 +53,7 @@ var listOptions metav1.ListOptions
 
 // ListGroupVersions list all GV
 func ListGroupVersions(client *kubernetes.Clientset, ch chan<- *metav1.APIGroupList) {
-	groupVersions, err := client.ServerGroups()
+	groupVersions, err := Discovery.ServerGroups()
 	if err != nil {
 		logrus.Fatal(err)
 	}

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -155,7 +155,7 @@ func surveyMissingValues() error {
 	dstClusterName := viperConfig.GetString("TargetClusterName")
 	if viperConfig.GetString("TargetCluster") == "true" && dstClusterName != "" {
 		api.KubeConfig.CurrentContext = api.ClusterNames[dstClusterName]
-		if err := api.CreateK8sDstClient(dstClusterName); err != nil {
+		if err := api.CreateDiscoveryClient(dstClusterName); err != nil {
 			return errors.Wrap(err, "k8s api client failed to create for destination cluster")
 		}
 	}
@@ -398,6 +398,25 @@ func surveyConfigPaths() error {
 			return err
 		}
 		viperConfig.Set("RegistriesConfigFile", config)
+	}
+
+	return nil
+}
+
+func createAPIClients() error {
+	if api.O7tClient != nil && api.K8sClient != nil {
+		return nil
+	}
+	if err := api.CreateDiscoveryClient(viperConfig.GetString("ClusterName")); err != nil {
+		return errors.Wrap(err, "discovery api client failed to create")
+	}
+
+	if err := api.CreateK8sClient(viperConfig.GetString("ClusterName")); err != nil {
+		return errors.Wrap(err, "k8s api client failed to create")
+	}
+
+	if err := api.CreateO7tClient(viperConfig.GetString("ClusterName")); err != nil {
+		return errors.Wrap(err, "OpenShift api client failed to create")
 	}
 
 	return nil


### PR DESCRIPTION
This reverts commit 35d037ea729d3805130279e858366e520a677bda.

Removing discovery and GroupVersion reporting which are an unsupported feature.